### PR TITLE
feature_lms-crawler: 과목별 과제 데이터 추출 로직 구현

### DIFF
--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -1,6 +1,7 @@
-import urllib.parse
-import requests
-from bs4 import BeautifulSoup
+import urllib.parse             #ID 추출
+import requests                 #서버 통신
+import re                       #과목명 정제
+from bs4 import BeautifulSoup   #html > python 객체로 변환하여 탐색
 from lms_login import login_to_lms
 
 def get_enrolled_courses(session):
@@ -20,18 +21,33 @@ def get_enrolled_courses(session):
             course_id = urllib.parse.parse_qs(parsed_url.query).get('id', [None])[0]
             
             if course_id and course_id not in courses:
-                # trim
-                course_name = link.text.strip().replace('\n', ' ')
-                courses[course_id] = course_name
-                print(f"   [발견] ID: {course_id} | 과목명: {course_name}")
+                raw_text = link.text.strip()
+                course_name = link.get('title', '').strip()
                 
+                if not course_name:
+                    lines = [line.strip() for line in raw_text.split('\n') if line.strip()]
+                    for line in lines:
+                        #(5110007-01) 형태의 과목코드 탐색
+                        if re.search(r'\([0-9]+-[0-9]+\)', line):
+                            course_name = line
+                            break
+                            
+                    if not course_name and '진행중' in lines:
+                        idx = lines.index('진행중')
+                        if idx + 1 < len(lines):
+                            course_name = lines[idx + 1]
+                            
+                if course_name:
+                    courses[course_id] = course_name
+                    print(f"[추출] ID: {course_id} | 과목명: {course_name}")
+
     print(f"\n총 {len(courses)}개의 과목을 찾았습니다.")
     return courses
 
 if __name__ == "__main__":
     session, message = login_to_lms()
     if session:
-        print("LMS 로그인 성공")
+        print("LMS 로그인 성공\n")
         get_enrolled_courses(session)
     else:
         print(f"로그인 실패: {message}")

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -8,41 +8,50 @@ def get_enrolled_courses(session):
     dashboard_url = "https://lms.chungbuk.ac.kr/"
     courses = {}
 
-    # 대시보드 접근 및 html 파일을 soup 객체로 변환
-    resp = session.get(dashboard_url, timeout=10)
-    soup = BeautifulSoup(resp.text, 'html.parser')
+    try:
+        # 대시보드 접근 및 html 파일을 soup 객체로 변환
+        resp = session.get(dashboard_url, timeout=10)
+        resp.raise_for_status() # 404, 500 에러 발생 시 예외 발생
+        soup = BeautifulSoup(resp.text, 'html.parser')
 
-    # 페이지 내 모든 앵커에서 개별 과목 페이지 특유의 URL 구조 탐색
-    for link in soup.find_all('a', href=True):
-        href = link['href']
-        if 'course/view.php?id=' in href:
-            # 주소 뒤의 쿼리 스트링에서 강의별 ID 추출하여 딕셔너리로 저장
-            parsed_url = urllib.parse.urlparse(href)
-            course_id = urllib.parse.parse_qs(parsed_url.query).get('id', [None])[0]
-            
-            if course_id and course_id not in courses:
-                raw_text = link.text.strip()
-                course_name = link.get('title', '').strip()
+        # 페이지 내 모든 앵커에서 개별 과목 페이지 특유의 URL 구조 탐색
+        for link in soup.find_all('a', href=True):
+            href = link['href']
+            if 'course/view.php?id=' in href:
+                # 주소 뒤의 쿼리 스트링에서 강의별 ID 추출하여 딕셔너리로 저장
+                parsed_url = urllib.parse.urlparse(href)
+                course_id = urllib.parse.parse_qs(parsed_url.query).get('id', [None])[0]
                 
-                if not course_name:
-                    lines = [line.strip() for line in raw_text.split('\n') if line.strip()]
-                    for line in lines:
-                        #(5110007-01) 형태의 과목코드 탐색
-                        if re.search(r'\([0-9]+-[0-9]+\)', line):
-                            course_name = line
-                            break
-                            
-                    if not course_name and '진행중' in lines:
-                        idx = lines.index('진행중')
-                        if idx + 1 < len(lines):
-                            course_name = lines[idx + 1]
-                            
-                if course_name:
-                    courses[course_id] = course_name
-                    print(f"[추출] ID: {course_id} | 과목명: {course_name}")
+                if course_id and course_id not in courses:
+                    raw_text = link.text.strip()
+                    course_name = ""
+                    
+                    if link.get('title'):
+                        course_name = link.get('title').strip()
+                    
+                    if not course_name:
+                        lines = [line.strip() for line in raw_text.split('\n') if line.strip()]
+                        for line in lines:
+                            #(5110007-01) 형태의 과목코드 탐색
+                            if re.search(r'\([0-9]+-[0-9]+\)', line):
+                                course_name = line
+                                break
+                                
+                        if not course_name and '진행중' in lines:
+                            idx = lines.index('진행중')
+                            if idx + 1 < len(lines):
+                                course_name = lines[idx + 1]
+                                
+                    if course_name:
+                        courses[course_id] = course_name
+                        print(f"[추출] ID: {course_id} | 과목명: {course_name}")
 
-    print(f"\n총 {len(courses)}개의 과목을 찾았습니다.")
-    return courses
+        print(f"\n총 {len(courses)}개의 과목을 찾았습니다.")
+        return courses
+
+    except Exception as e:
+        print(f"[{course_name}] 과목 목록 추출 중 오류 발생: {e}")
+        return {}
 
 if __name__ == "__main__":
     session, message = login_to_lms()

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -2,10 +2,23 @@ import requests
 from bs4 import BeautifulSoup
 from lms_login import login_to_lms
 
+def get_enrolled_courses(session):
+    dashboard_url = "https://lms.chungbuk.ac.kr/"
+
+    #대시보드 접근 및 html 파일을 soup 객체로 변환
+    resp = session.get(dashboard_url, timeout=10)
+    soup = BeautifulSoup(resp.text, 'html.parser')
+
+    #페이지 내 모든 앵커에서 개별 과목 페이지 특유의 URL 구조 탐색
+    for link in soup.find_all('a', href=True):
+        if 'course/view.php?id=' in link['href']:
+            print("찾은 과목:", link.text.strip())
+    return {}
+
 if __name__ == "__main__":
     session, message = login_to_lms()
-    
     if session:
         print("LMS 로그인 성공")
+        get_enrolled_courses(session)
     else:
         print(f"로그인 실패: {message}")

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -1,0 +1,11 @@
+import requests
+from bs4 import BeautifulSoup
+from lms_login import login_to_lms
+
+if __name__ == "__main__":
+    session, message = login_to_lms()
+    
+    if session:
+        print("LMS 로그인 성공")
+    else:
+        print(f"로그인 실패: {message}")

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -1,4 +1,4 @@
-import urllib.parse             #ID 추출
+import urllib.parse             #과목별 ID 추출
 import requests                 #서버 통신
 import re                       #과목명 정제
 from bs4 import BeautifulSoup   #html > python 객체로 변환하여 탐색
@@ -72,10 +72,19 @@ def get_assignments_for_course(session, course_id, course_name):
                     a_url = cols[1].find('a')['href']
                     a_due = cols[2].text.strip()
                     a_status = cols[3].text.strip()
+
+                    # 과제 고유 ID 추출 (URL의 id 파라미터 값)
+                    parsed_assign_url = urllib.parse.urlparse(a_url)
+                    a_id = urllib.parse.parse_qs(parsed_assign_url.query).get('id', [None])[0]
                     
+                    # '2026-05-9 9:5' -> '2026-05-09 09:05' 형태로 정규화
+                    a_due = re.sub(r'(?<!\d)(\d)(?!\d)', r'0\1', a_due)
+
                     # 데이터 반환을 위해 리스트에 저장
                     assignments.append({
+                        'course_id': course_id,
                         'course_name': course_name,
+                        'assignment_id': a_id,
                         'assignment_name': a_name,
                         'due_date': a_due,
                         'status': a_status,
@@ -85,7 +94,8 @@ def get_assignments_for_course(session, course_id, course_name):
         return assignments
     
     except Exception as e:
-        print(f"[{course_name}] 에러: {e}"); return []
+        print(f"과제 목록 추출 중 오류 발생: {e}")
+        return []
 
 def crawl_all_assignments(session):
     # 모든 과제 데이터를 하나의 리스트로 통합
@@ -96,7 +106,10 @@ def crawl_all_assignments(session):
     for course_id, course_name in courses.items():
         assign_list = get_assignments_for_course(session, course_id, course_name)
         all_assignments.extend(assign_list)
-        
+    
+    #마감일을 기준으로 오름차순 정렬
+    all_assignments.sort(key=lambda x: x['due_date'])
+
     return all_assignments
 
 if __name__ == "__main__":

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -44,7 +44,7 @@ def get_enrolled_courses(session):
                                 
                     if course_name:
                         courses[course_id] = course_name
-                        print(f"[추출] ID: {course_id} | 과목명: {course_name}")
+                        print(f"ID: {course_id} | 과목명: {course_name}")
 
         print(f"\n총 {len(courses)}개의 과목을 찾았습니다.")
         return courses
@@ -53,10 +53,25 @@ def get_enrolled_courses(session):
         print(f"[{course_name}] 과목 목록 추출 중 오류 발생: {e}")
         return {}
 
+def get_assignments_for_course(session, course_id, course_name):
+    # 과제 목록 페이지 URL 생성
+    assign_index_url = f"https://lms.chungbuk.ac.kr/mod/assign/index.php?id={course_id}"
+    
+    resp = session.get(assign_index_url, timeout=10)
+    # 서버 응답이 200인지 확인하여 접속 여부 출력
+    if resp.status_code == 200:
+        print(f"[접속성공] {course_name} 과제 페이지에 연결되었습니다.")
+    else:
+        print(f"[접속실패] {course_name} 페이지 응답 코드: {resp.status_code}")
+    
+    return []
+
 if __name__ == "__main__":
     session, message = login_to_lms()
     if session:
-        print("LMS 로그인 성공\n")
-        get_enrolled_courses(session)
+        courses = get_enrolled_courses(session)
+        for c_id, c_name in courses.items():
+            # 정의한 함수를 여기서 바로 호출하여 접속 테스트 진행
+            get_assignments_for_course(session, c_id, c_name)
     else:
         print(f"로그인 실패: {message}")

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -73,13 +73,6 @@ def get_assignments_for_course(session, course_id, course_name):
                     a_due = cols[2].text.strip()
                     a_status = cols[3].text.strip()
                     
-                    # [Step 5 핵심] 수집하는 모든 데이터를 즉시 출력
-                    print(f"\n{course_name}")
-                    print(f"-과제명: {a_name}")
-                    print(f"-마감일: {a_due}")
-                    print(f"-상태  : {a_status}")
-                    print(f"-링크  : {a_url}")
-                    
                     # 데이터 반환을 위해 리스트에 저장
                     assignments.append({
                         'course_name': course_name,
@@ -94,11 +87,30 @@ def get_assignments_for_course(session, course_id, course_name):
     except Exception as e:
         print(f"[{course_name}] 에러: {e}"); return []
 
+def crawl_all_assignments(session):
+    # 모든 과제 데이터를 하나의 리스트로 통합
+    all_assignments = []
+
+    courses = get_enrolled_courses(session)
+    
+    for course_id, course_name in courses.items():
+        assign_list = get_assignments_for_course(session, course_id, course_name)
+        all_assignments.extend(assign_list)
+        
+    return all_assignments
+
 if __name__ == "__main__":
     session, message = login_to_lms()
     if session:
-        courses = get_enrolled_courses(session)
-        for c_id, c_name in courses.items():
-            get_assignments_for_course(session, c_id, c_name)
+        final_assignments = crawl_all_assignments(session)
+
+        print("\n" + "="*50)
+        print(f"       학기 과제 현황 요약 (총 {len(final_assignments)}건)")
+        print("="*50)
+        
+        for idx, item in enumerate(final_assignments, 1):
+            print(f"{idx:2d}. [{item['course_name']}] {item['assignment_name']}")
+            print(f"    - 마감: {item['due_date']} | 상태: {item['status']}")
+            print(f"    - 링크: {item['url']}\n")
     else:
         print(f"로그인 실패: {message}")

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -1,19 +1,32 @@
+import urllib.parse
 import requests
 from bs4 import BeautifulSoup
 from lms_login import login_to_lms
 
 def get_enrolled_courses(session):
     dashboard_url = "https://lms.chungbuk.ac.kr/"
+    courses = {}
 
-    #대시보드 접근 및 html 파일을 soup 객체로 변환
+    # 대시보드 접근 및 html 파일을 soup 객체로 변환
     resp = session.get(dashboard_url, timeout=10)
     soup = BeautifulSoup(resp.text, 'html.parser')
 
-    #페이지 내 모든 앵커에서 개별 과목 페이지 특유의 URL 구조 탐색
+    # 페이지 내 모든 앵커에서 개별 과목 페이지 특유의 URL 구조 탐색
     for link in soup.find_all('a', href=True):
-        if 'course/view.php?id=' in link['href']:
-            print("찾은 과목:", link.text.strip())
-    return {}
+        href = link['href']
+        if 'course/view.php?id=' in href:
+            # 주소 뒤의 쿼리 스트링에서 강의별 ID 추출하여 딕셔너리로 저장
+            parsed_url = urllib.parse.urlparse(href)
+            course_id = urllib.parse.parse_qs(parsed_url.query).get('id', [None])[0]
+            
+            if course_id and course_id not in courses:
+                # trim
+                course_name = link.text.strip().replace('\n', ' ')
+                courses[course_id] = course_name
+                print(f"   [발견] ID: {course_id} | 과목명: {course_name}")
+                
+    print(f"\n총 {len(courses)}개의 과목을 찾았습니다.")
+    return courses
 
 if __name__ == "__main__":
     session, message = login_to_lms()

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -46,7 +46,6 @@ def get_enrolled_courses(session):
                         courses[course_id] = course_name
                         print(f"ID: {course_id} | 과목명: {course_name}")
 
-        print(f"\n총 {len(courses)}개의 과목을 찾았습니다.")
         return courses
 
     except Exception as e:
@@ -56,22 +55,50 @@ def get_enrolled_courses(session):
 def get_assignments_for_course(session, course_id, course_name):
     # 과제 목록 페이지 URL 생성
     assign_index_url = f"https://lms.chungbuk.ac.kr/mod/assign/index.php?id={course_id}"
+    assignments = []
+
+    try:
+        resp = session.get(assign_index_url, timeout=10)
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        table = soup.find('table', class_='generaltable')
+        
+        if table:
+            rows = table.find('tbody').find_all('tr') if table.find('tbody') else table.find_all('tr')[1:]
+            for row in rows:
+                cols = row.find_all(['td', 'th'])
+                if len(cols) >= 4 and cols[1].find('a'):
+                    # 데이터 추출
+                    a_name = cols[1].find('a').text.strip()
+                    a_url = cols[1].find('a')['href']
+                    a_due = cols[2].text.strip()
+                    a_status = cols[3].text.strip()
+                    
+                    # [Step 5 핵심] 수집하는 모든 데이터를 즉시 출력
+                    print(f"\n{course_name}")
+                    print(f"-과제명: {a_name}")
+                    print(f"-마감일: {a_due}")
+                    print(f"-상태  : {a_status}")
+                    print(f"-링크  : {a_url}")
+                    
+                    # 데이터 반환을 위해 리스트에 저장
+                    assignments.append({
+                        'course_name': course_name,
+                        'assignment_name': a_name,
+                        'due_date': a_due,
+                        'status': a_status,
+                        'url': a_url
+                    })
+
+        return assignments
     
-    resp = session.get(assign_index_url, timeout=10)
-    # 서버 응답이 200인지 확인하여 접속 여부 출력
-    if resp.status_code == 200:
-        print(f"[접속성공] {course_name} 과제 페이지에 연결되었습니다.")
-    else:
-        print(f"[접속실패] {course_name} 페이지 응답 코드: {resp.status_code}")
-    
-    return []
+    except Exception as e:
+        print(f"[{course_name}] 에러: {e}"); return []
 
 if __name__ == "__main__":
     session, message = login_to_lms()
     if session:
         courses = get_enrolled_courses(session)
         for c_id, c_name in courses.items():
-            # 정의한 함수를 여기서 바로 호출하여 접속 테스트 진행
             get_assignments_for_course(session, c_id, c_name)
     else:
         print(f"로그인 실패: {message}")

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -44,7 +44,7 @@ def get_enrolled_courses(session):
                                 
                     if course_name:
                         courses[course_id] = course_name
-                        print(f"ID: {course_id} | 과목명: {course_name}")
+                        #print(f"ID: {course_id} | 과목명: {course_name}")
 
         return courses
 

--- a/server/lms_crawler.py
+++ b/server/lms_crawler.py
@@ -77,8 +77,9 @@ def get_assignments_for_course(session, course_id, course_name):
                     parsed_assign_url = urllib.parse.urlparse(a_url)
                     a_id = urllib.parse.parse_qs(parsed_assign_url.query).get('id', [None])[0]
                     
-                    # '2026-05-9 9:5' -> '2026-05-09 09:05' 형태로 정규화
+                    # 'yyyy-mm-d h:m' -> 'yyyy-mm-ddThh:mm:ss' 형태로 정규화
                     a_due = re.sub(r'(?<!\d)(\d)(?!\d)', r'0\1', a_due)
+                    a_due = a_due.replace(" ", "T") + ":00"
 
                     # 데이터 반환을 위해 리스트에 저장
                     assignments.append({

--- a/server/lms_login.py
+++ b/server/lms_login.py
@@ -4,15 +4,15 @@ from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 
 load_dotenv()
-USER_ID = os.getenv("LMS_ID")
-USER_PW = os.getenv("LMS_PW")
-
-if not USER_ID or not USER_PW:
-    raise ValueError(".env 파일에 LMS_ID와 LMS_PW가 설정되지 않았습니다")
 
 LOGIN_URL = "https://lms.chungbuk.ac.kr/login/index.php"
 
 def login_to_lms():
+    user_id = os.getenv("LMS_ID")
+    user_pw = os.getenv("LMS_PW")
+    
+    if not user_id or not user_pw:
+        return None, ".env 파일에 LMS_ID 또는 LMS_PW가 설정되지 않았습니다."
     # 쿠키를 유지할 세션 생성
     session = requests.Session()
     
@@ -31,8 +31,8 @@ def login_to_lms():
             
         # 데이터 전송 (로그인 시도)
         payload = {
-            "username": USER_ID,
-            "password": USER_PW,
+            "username": user_id,
+            "password": user_pw,
             "logintoken": logintoken
         }
         post_resp = session.post(LOGIN_URL, data=payload, timeout=10)


### PR DESCRIPTION
### 개요
인증된 세션을 활용하여 LMS 서버로부터 사용자의 수강 과목 및 전체 과제 데이터를 추출하고, FE에서 처리하기 쉬운 JSON 친화적 딕셔너리/리스트 구조로 정규화하는 데이터 파이프라인을 구현

### 작업 내용
- 메인 대시보드 URL 크롤링 및 정규식을 활용한 과목명, 과목 고유 ID 맵핑 (get_enrolled_courses)
- 개별 과목의 과제 인덱스 페이지(mod/assign/index.php) 탐색 및 테이블 데이터 파싱 (get_assignments_for_course)
- 과제 고유 ID, 과제명, 마감일, 제출 상태, 원본 링크 추출 및 마감일 포맷 정규
- 리스트/딕셔너리 형태로 통합 및 마감일 기준 오름차순으로 최종 결과물 정렬

### 로직 변경 안내
- LMS 서버가 CSR(Client Side Rendering)이 아닌 SSR(Server Side Rendering) 방식을 채택하고 있어, API 직접 호출 대신 HTML 파싱 기반 크롤링으로 전환했습니다. 이에 따라 당초 계획했던 1초 내외에서 3~8초 가량으로 소요시간이 증가했습니다.
- 해당 문제를 해결하기 위해 ThreadPoolExecutor를 통한 Multi-threading을 시도했습니다만, 세션 락 메커니즘으로 인해 Multi-threading이 불가하며 오버헤드만큼의 소요시간 증가를 확인하여 롤백 처리하였습니다.
- 초기 실행 시엔 DNS 조회 및 커넥션 수립 등으로 인해 8~9초, 연속 실행 시에는 유지된 네트워크 세션과 서버측 데이터 캐싱으로 인해 3.5초 내외로 소요되는 것을 확인하였습니다.
- 이에 따라 차후 호스팅 서버를 계획했던 Vercel이 아닌 24시간 서버로 변경하거나 DB를 구축하는 등의 소요가 필요할 것으로 예상됩니다. 

### 관련 이슈
Closes https://github.com/KadenID/OSBP_Team_NULL/issues/5

### 테스트 결과
- .env 환경 변수를 통한 정상 로그인 및 세션 유지 확인
- 전체 수강 과목의 과제 목록이 누락 없이 딕셔너리 리스트로 반환됨을 확인
- 마감일 기준 오름차순 정렬이 정상 작동함을 터미널 리포트 출력을 통해 검증 완료 (if __name__ == "__main__": 블록 활용)
<img width="848" height="813" alt="image" src="https://github.com/user-attachments/assets/79d5074a-17fa-4238-86df-872d17f243ae" />
</br>

- 테스트 출력 상에는 과제 고유 ID는 추가하지 않았음