### PR TITLE
Feature assignment detail : 과제 상세 보기 기능

### DIFF
--- a/client/src/Components/assignment-tab/AssignmentDetail.css
+++ b/client/src/Components/assignment-tab/AssignmentDetail.css
@@ -1,0 +1,76 @@
+.detail-overlay {
+  position: fixed;
+  top: 0;     
+  left: 0;
+
+  width: 100%;
+  height: 100%;
+
+  background: rgba(0, 0, 0, 0.5);
+
+  display: grid;
+  justify-content: center;
+  align-items: center;
+
+  z-index: 99999;
+}
+
+.detail-modal {
+  place-self: center;
+  width: 600px;
+  max-height: 80vh;
+  overflow-y: auto;
+
+  background: var(--bg-card);
+  border-radius: 20px;
+  padding: 28px;
+  position: relative;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.2);
+}
+
+.detail-text {
+  white-space: pre-wrap;
+  line-height: 1.7;
+  font-size: 15px;
+  font-family: inherit;
+}
+
+.close-btn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+
+  width: 36px;
+  height: 36px;
+
+  border: none;
+  border-radius: 50%;
+
+  background: rgba(0,0,0,0.08);
+
+  font-size: 20px;
+  font-weight: bold;
+
+  cursor: pointer;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  z-index: 10;
+}
+
+.close-btn:hover {
+  background: rgba(0,0,0,0.15);
+}
+
+.detail-info {
+  margin-bottom: 15px;
+  font-size: 0.9em;
+  color: #666;
+}
+
+.detail-footer {
+  margin-top: 20px;
+  text-align: center;
+}

--- a/client/src/Components/assignment-tab/AssignmentDetail.css
+++ b/client/src/Components/assignment-tab/AssignmentDetail.css
@@ -26,6 +26,7 @@
   padding: 28px;
   position: relative;
   box-shadow: 0 8px 30px rgba(0,0,0,0.2);
+  color: var(--text-main);
 }
 
 .detail-text {
@@ -33,6 +34,7 @@
   line-height: 1.7;
   font-size: 15px;
   font-family: inherit;
+  color: var(--text-main);
 }
 
 .close-btn {
@@ -73,4 +75,90 @@
 .detail-footer {
   margin-top: 20px;
   text-align: center;
+}
+
+.edit-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.detail-section-title {
+  font-size: 0.9em;
+  font-weight: bold;
+  color: #888;
+}
+
+.edit-btn {
+  font-size: 13px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-main);
+  cursor: pointer;
+}
+
+.edit-btn:hover { background: rgba(0,0,0,0.06); }
+
+.edit-area {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detail-textarea {
+  width: 100%;
+  min-height: 160px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.6;
+  resize: vertical;
+  background: var(--bg-card);
+  color: var(--text-main);
+  box-sizing: border-box;
+}
+
+.detail-textarea:focus { outline: none; border-color: #1890ff; }
+
+.edit-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.save-btn {
+  padding: 6px 16px;
+  background: #1890ff;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.save-btn:hover { background: #40a9ff; }
+
+.cancel-btn {
+  padding: 6px 16px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text-main);
+}
+
+.cancel-btn:hover { background: rgba(0,0,0,0.06); }
+
+@media screen and (max-width: 768px) {
+  .detail-modal {
+    width: 90vw;
+    padding: 20px;
+    max-height: 90vh;
+  }
 }

--- a/client/src/Components/assignment-tab/AssignmentDetail.jsx
+++ b/client/src/Components/assignment-tab/AssignmentDetail.jsx
@@ -1,23 +1,49 @@
 import React, { useEffect, useState } from 'react';
 import './AssignmentDetail.css';
+import useAssignmentStore from '../../store/useAssignmentStore';
 
-function AssignmentDetail({ assignment, onClose }) {
-    
+function AssignmentDetail({ assignment, onClose, updateDescription }) {
+
   const [description, setDescription] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState("");
 
   useEffect(() => {
-  setDescription(""); // 
+    setDescription("");
+    setIsEditing(false);
 
   if (assignment?.source === 'lms') {
     const mockDescriptions = {
       default: "현재 상세 설명을 불러올 수 없습니다.\nLMS 페이지에서 직접 확인해주세요."
     };
     setDescription(mockDescriptions[assignment.id] ?? mockDescriptions.default);
+  } else if (assignment?.source === 'user') {
+      // 스토어에 저장된 description 불러오기
+      setDescription(assignment.description ?? "");
   }
 }, [assignment]);
 
 
   if (!assignment) return null;
+
+  // 생성 과제 편집
+  const handleEditStart = () => {
+    setEditText(description);
+    setIsEditing(true);
+  };
+
+  // 생성 과제 저장
+  const handleSave = () => {
+    updateDescription(assignment.id, editText);
+    setDescription(editText);
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
+
+  const isUser = assignment.source === 'user';
 
   return (
     <div className="detail-overlay" onClick={onClose}>
@@ -30,18 +56,43 @@ function AssignmentDetail({ assignment, onClose }) {
         <h3>과제 상세 정보</h3>
 
         {/* 과제 기본 정보 요약 */}
-        <div className="detail-info" style={{ marginBottom: '15px', fontSize: '0.9em', color: '#666' }}>
+        <div className="detail-info" style={{ marginBottom: '15px', fontSize: '0.9em', color: '#a3a3a3' }}>
           <p><strong>강의:</strong> {assignment.subject}</p>
           <p><strong>과제:</strong> {assignment.task}</p>
         </div>
 
         <hr />
 
+        {/* user 과제일 때만 편집 버튼 표시 */}
+        {isUser && !isEditing && (
+          <div className="edit-header">
+            <span className="detail-section-title">상세 설명</span>
+            <button className="edit-btn" onClick={handleEditStart}>편집하기</button>
+          </div>
+        )}
+
+        {isEditing ? (
+          <div className="edit-area">
+            <textarea
+              className="detail-textarea"
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              placeholder="과제 상세 설명을 입력하세요..."
+              autoFocus
+            />
+            <div className="edit-actions">
+              <button className="save-btn" onClick={handleSave}>저장</button>
+              <button className="cancel-btn" onClick={handleCancel}>취소</button>
+            </div>
+          </div>
+        ) : (
+
         <pre className="detail-text">
             {description.trim() !== ""
                 ? description
                 : "상세 설명 데이터가 없습니다. 아래 링크를 참조하거나 LMS를 확인하세요."}
         </pre>
+      )}
 
 
         {/* url이 있을 때만 링크 렌더링 */}

--- a/client/src/Components/assignment-tab/AssignmentDetail.jsx
+++ b/client/src/Components/assignment-tab/AssignmentDetail.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import './AssignmentDetail.css';
+
+function AssignmentDetail({ assignment, onClose }) {
+    
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+  setDescription(""); // 
+
+  if (assignment?.source === 'lms') {
+    const mockDescriptions = {
+      default: "현재 상세 설명을 불러올 수 없습니다.\nLMS 페이지에서 직접 확인해주세요."
+    };
+    setDescription(mockDescriptions[assignment.id] ?? mockDescriptions.default);
+  }
+}, [assignment]);
+
+
+  if (!assignment) return null;
+
+  return (
+    <div className="detail-overlay" onClick={onClose}>
+      <div
+        className="detail-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button className="close-btn" onClick={onClose}>✕</button>
+
+        <h3>과제 상세 정보</h3>
+
+        {/* 과제 기본 정보 요약 */}
+        <div className="detail-info" style={{ marginBottom: '15px', fontSize: '0.9em', color: '#666' }}>
+          <p><strong>강의:</strong> {assignment.subject}</p>
+          <p><strong>과제:</strong> {assignment.task}</p>
+        </div>
+
+        <hr />
+
+        <pre className="detail-text">
+            {description.trim() !== ""
+                ? description
+                : "상세 설명 데이터가 없습니다. 아래 링크를 참조하거나 LMS를 확인하세요."}
+        </pre>
+
+
+        {/* url이 있을 때만 링크 렌더링 */}
+        {assignment.url && (
+          <div className="detail-footer">
+            <a href={assignment.url} target="_blank" rel="noopener noreferrer" className="lms-link">
+              LMS 페이지로 이동
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AssignmentDetail;

--- a/client/src/Components/assignment-tab/AssignmentDetail.jsx
+++ b/client/src/Components/assignment-tab/AssignmentDetail.jsx
@@ -1,41 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import './AssignmentDetail.css';
-import useAssignmentStore from '../../store/useAssignmentStore';
 
 function AssignmentDetail({ assignment, onClose, updateDescription }) {
 
-  const [description, setDescription] = useState("");
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState("");
 
-  useEffect(() => {
-    setDescription("");
-    setIsEditing(false);
-
-  if (assignment?.source === 'lms') {
-    const mockDescriptions = {
-      default: "현재 상세 설명을 불러올 수 없습니다.\nLMS 페이지에서 직접 확인해주세요."
-    };
-    setDescription(mockDescriptions[assignment.id] ?? mockDescriptions.default);
-  } else if (assignment?.source === 'user') {
-      // 스토어에 저장된 description 불러오기
-      setDescription(assignment.description ?? "");
-  }
-}, [assignment]);
-
+  // 객체 직접 참조
+  const description = assignment.source === 'lms'
+    ? "현재 상세 설명을 불러올 수 없습니다.\nLMS 페이지에서 직접 확인해주세요."
+    : (assignment.description ?? "");
 
   if (!assignment) return null;
 
   // 생성 과제 편집
   const handleEditStart = () => {
-    setEditText(description);
+    setEditText(assignment.description || "");
     setIsEditing(true);
   };
 
   // 생성 과제 저장
   const handleSave = () => {
     updateDescription(assignment.id, editText);
-    setDescription(editText);
     setIsEditing(false);
   };
 

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -264,8 +264,15 @@
   background: #0e0e0e;
 }
 
+/* 과제 생성 캘린더 영역 */
 .input-field input[type="datetime-local"]::-webkit-calendar-picker-indicator {
-  filter: invert(1);
+  filter: invert(0.5); 
+  cursor: pointer;
+}
+
+[data-theme='dark'] .input-field input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+  filter: invert(1); 
+  cursor: pointer;
 }
 
 .add-submit-btn {

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -23,13 +23,17 @@
 .assignment-item {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
   align-items: center;
   padding: 11px;
   height: 110px;
+  min-width: 0;
+  min-height: 150px;
   background-color: var(--bg-card); 
   border: 1px solid var(--border);
   border-radius: 12px;
   transition: transform 0.2s;
+  box-sizing: border-box;
 }
 
 .assignment-item:hover {
@@ -94,6 +98,7 @@
   align-items: flex-end; 
   gap: 5px; 
   text-align: right;
+  flex-shrink: 0;  
 }
 
 /* 제출 상태 라벨 */
@@ -364,5 +369,12 @@ body.modal-open .left:hover {
     flex-direction: column;
     align-items: flex-end;
     justify-content: space-between;
+  }
+}
+
+@media screen and (max-width: 1300px) {
+  .assignment-item {
+    height: auto;        /* 고정 높이 해제 */
+    min-height: 110px;
   }
 }

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -217,6 +217,7 @@
 /* 과제 생성창 */
 .add-form {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
   gap: 12px;
   background-color: var(--bg-card);
@@ -228,12 +229,14 @@
 
 .input-group {
   display: flex;
+  flex-wrap: wrap;
   flex: 1;
   gap: 10px;
 }
 
 .input-field {
   display: flex;
+  flex-wrap: wrap;
   flex-direction: column;
   flex: 1;
   gap: 5px;

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -257,11 +257,13 @@
   background: var(--bg-card); 
   color: var(--text-main);       
   outline: none;
+  color-scheme: light;
 }
 
 [data-theme='dark'] .input-field input {
   border-color: #707070;
   background: #0e0e0e;
+  color-scheme: dark;
 }
 
 /* 과제 생성 캘린더 영역 */
@@ -271,7 +273,7 @@
 }
 
 [data-theme='dark'] .input-field input[type="datetime-local"]::-webkit-calendar-picker-indicator {
-  filter: invert(1); 
+  filter: none; 
   cursor: pointer;
 }
 

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -1,4 +1,5 @@
 import React, {useState, useMemo, useEffect} from 'react';
+import { createPortal } from 'react-dom';
 import './AssignmentTab.css';
 import useAssignmentStore from '../../store/useAssignmentStore';
 import AssignmentDetail from './AssignmentDetail';
@@ -251,21 +252,26 @@ function AssignmentTab() {
             ))}
       </ul>
     )}
-      {showModal && (<div className="modal-overlay">
-          <div className="modal"><p>과제를 삭제하시겠습니까?</p>
+      {showModal && createPortal(
+        <div className="modal-overlay">
+          <div className="modal">
+            <p>과제를 삭제하시겠습니까?</p>
             <div className="modal-buttons">
-            <button onClick={confirmDelete}>삭제</button>
-            <button onClick={() => setShowModal(false)}>취소</button>
+              <button onClick={confirmDelete}>삭제</button>
+              <button onClick={() => setShowModal(false)}>취소</button>
             </div>
-          </div >
-        </div>)}
+          </div>
+        </div>,
+        document.body
+      )}
         
-        {selectedAssignment && (
+        {selectedAssignment && createPortal(
           <AssignmentDetail
             assignment={selectedAssignment}
             onClose={() => setSelectedAssignment(null)}
-            />
-      )}
+          />,
+          document.body
+        )}
       </div>
     </div>
   );

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -47,7 +47,8 @@ function AssignmentTab() {
     fetchAssignments,
     addAssignment,
     deleteAssignment, 
-    toggleSubmit
+    toggleSubmit,
+    updateDescription
   } = useAssignmentStore();
 
   // 최초 렌더링 시 스토어의 API 호출 함수 실행 (store 내부에서 중복 호출 방지 처리)
@@ -138,6 +139,12 @@ function AssignmentTab() {
     deleteAssignment(targetId); // 스토어의 삭제 액션 실행
     setShowModal(false);        // 모달 닫기
     setTargetId(null);          // 타겟 ID 초기화
+  };
+
+  // 상세 모달에서 설명 저장 시 selectedAssignment 동기화
+  const handleUpdateDescription = (id, text) => {
+    updateDescription(id, text);
+    setSelectedAssignment(prev => ({ ...prev, description: text }));
   };
 
   // 상태 변경
@@ -269,6 +276,7 @@ function AssignmentTab() {
           <AssignmentDetail
             assignment={selectedAssignment}
             onClose={() => setSelectedAssignment(null)}
+            updateDescription={handleUpdateDescription}
           />,
           document.body
         )}

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -1,6 +1,7 @@
 import React, {useState, useMemo, useEffect} from 'react';
 import './AssignmentTab.css';
 import useAssignmentStore from '../../store/useAssignmentStore';
+import AssignmentDetail from './AssignmentDetail';
 
 const STATUS = {
   UNSUBMITTED: 'UNSUBMITTED',
@@ -66,6 +67,8 @@ function AssignmentTab() {
 
   const [showModal, setShowModal] = useState(false);
   const [targetId, setTargetId] = useState(null);
+
+  const [selectedAssignment, setSelectedAssignment] = useState(null); // 과제 상세보기
 
   
   // 모달 열림 상태 - hover 효과 제거 
@@ -212,6 +215,8 @@ function AssignmentTab() {
              <li
                 className={`assignment-item ${getItemClass(item.isExpired, item.isSubmitted)}`}
                 key={item.id}
+                onClick={() => setSelectedAssignment(item)}
+                style={{ cursor: 'pointer' }} 
                 >
 
               <div className="info"> {/* lms 과제인지 생성 과제인지 라벨링 */}
@@ -231,10 +236,10 @@ function AssignmentTab() {
                 <div className="item-actions"> {/* 생성과제 - 삭제, 완료 처리 버튼 영역 */}
                     {item.source === 'user' ? (
                       <>
-                        <button onClick={() => toggleSubmit(item.id)} className="action-btn toggle">
+                        <button onClick={(e) => { e.stopPropagation(); toggleSubmit(item.id); }} className="action-btn toggle">
                           {item.isSubmitted ? '진행으로 변경' : '완료 처리'}
                         </button>
-                        <button onClick={() => {setTargetId(item.id); setShowModal(true);}} className="action-btn delete">삭제</button>
+                        <button onClick={(e) => {e.stopPropagation(); setTargetId(item.id); setShowModal(true); }} className="action-btn delete">삭제</button>
                       </>
                     ) : (
                       <span className="lock-msg">시스템 관리항목</span>
@@ -254,6 +259,13 @@ function AssignmentTab() {
             </div>
           </div >
         </div>)}
+        
+        {selectedAssignment && (
+          <AssignmentDetail
+            assignment={selectedAssignment}
+            onClose={() => setSelectedAssignment(null)}
+            />
+      )}
       </div>
     </div>
   );

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -73,13 +73,13 @@ function AssignmentTab() {
   
   // 모달 열림 상태 - hover 효과 제거 
   useEffect(() => {
-    if (showModal) document.body.classList.add('modal-open');
+    if (showModal || selectedAssignment) document.body.classList.add('modal-open');
     else document.body.classList.remove('modal-open');
 
     return () => {
      document.body.classList.remove('modal-open');
     };
-  }, [showModal]);
+  }, [showModal, selectedAssignment]);
 
 
   // 과제 추가 로직

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -70,18 +70,18 @@ function AssignmentTab() {
   const [showModal, setShowModal] = useState(false);
   const [targetId, setTargetId] = useState(null);
 
-  const [selectedAssignment, setSelectedAssignment] = useState(null); // 과제 상세보기
+  const [selectedId, setSelectedId] = useState(null); // ID만 저장
 
   
   // 모달 열림 상태 - hover 효과 제거 
   useEffect(() => {
-    if (showModal || selectedAssignment) document.body.classList.add('modal-open');
+    if (showModal || selectedId) document.body.classList.add('modal-open');
     else document.body.classList.remove('modal-open');
 
     return () => {
      document.body.classList.remove('modal-open');
     };
-  }, [showModal, selectedAssignment]);
+  }, [showModal, selectedId]);
 
 
   // 과제 추가 로직
@@ -141,11 +141,10 @@ function AssignmentTab() {
     setTargetId(null);          // 타겟 ID 초기화
   };
 
-  // 상세 모달에서 설명 저장 시 selectedAssignment 동기화
-  const handleUpdateDescription = (id, text) => {
-    updateDescription(id, text);
-    setSelectedAssignment(prev => ({ ...prev, description: text }));
-  };
+  // 선택된 과제 데이터를 최신으로 참조
+  const selectedAssignment = useMemo(() => 
+    assignment.find(item => item.id === selectedId) ?? null,
+  [assignment, selectedId]);
 
   // 상태 변경
   const toggleTag = (tag) => {
@@ -223,7 +222,7 @@ function AssignmentTab() {
              <li
                 className={`assignment-item ${getItemClass(item.isExpired, item.isSubmitted)}`}
                 key={item.id}
-                onClick={() => setSelectedAssignment(item)}
+                onClick={() => setSelectedId(item.id)}
                 style={{ cursor: 'pointer' }} 
                 >
 
@@ -275,8 +274,8 @@ function AssignmentTab() {
         {selectedAssignment && createPortal(
           <AssignmentDetail
             assignment={selectedAssignment}
-            onClose={() => setSelectedAssignment(null)}
-            updateDescription={handleUpdateDescription}
+            onClose={() => setSelectedId(null)} 
+            updateDescription={updateDescription}
           />,
           document.body
         )}

--- a/client/src/Components/main_page/MainPage.css
+++ b/client/src/Components/main_page/MainPage.css
@@ -50,10 +50,12 @@
 
 .dashboard {
   display: flex;
+  flex-direction: row;
   gap: 25px;
   margin: 20px auto;
   min-height: 70vh;
   max-width: 1400px;
+  flex-wrap: wrap;
 }
 
 .right, .left {
@@ -71,7 +73,17 @@
   display: flex;
   flex-direction: column;
   gap: 25px;
+  min-width: 0;
+  flex-basis: 600px;
+  flex-grow: 2;
 }
+
+.right {
+  flex: 1;
+  min-width: 200px; 
+  flex-basis: 280px;
+  flex-grow: 1;
+} 
 
 .right:hover, .left:hover {
   box-shadow: 0 10px 26px var(--shadow-hover);
@@ -123,6 +135,18 @@ header h1 {
   font-size: 13px;
   font-weight: 600;
   gap: 8px;
+}
+
+@media screen and (max-width: 1300px) {
+  .left-section {
+    flex-basis: 100%;  /* 과제탭이 전체 너비 차지 */
+    min-width: 0;
+  }
+
+  .right {
+    flex-basis: 100%;  /* AI탭도 전체 너비로 아래 배치 */
+    min-width: 0;
+  }
 }
 
 @media screen and (max-width: 768px) {

--- a/client/src/Components/main_page/MainPage.jsx
+++ b/client/src/Components/main_page/MainPage.jsx
@@ -14,7 +14,7 @@ function MainPage() {
     const saved = localStorage.getItem('theme');
     if (saved) return saved;
 
-    const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const systemDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
     return systemDark ? 'dark' : 'light';
     });
   

--- a/client/src/store/useAssignmentStore.js
+++ b/client/src/store/useAssignmentStore.js
@@ -56,6 +56,13 @@ const useAssignmentStore = create(persist(
     assignment: state.assignment.map(item => 
       item.id === id ? { ...item, isSubmitted: !item.isSubmitted } : item
     )
+  })),
+  
+  // 커스텀 과제 설명 작성
+  updateDescription: (id, description) => set((state) => ({
+    assignment: state.assignment.map(item =>
+      item.id === id ? { ...item, description } : item
+    )
   }))
 }),
     {

--- a/client/src/store/useAssignmentStore.js
+++ b/client/src/store/useAssignmentStore.js
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware'; // 생성과제 로컬스토리지를 위한 persist
 
-const useAssignmentStore = create((set, get) => ({
-  assignment: [],
-  isLoading: false,
-  isFetched: false, // 데이터를 이미 불러왔는지 확인하는 플래그
+const useAssignmentStore = create(persist(
+  (set, get) => ({
+    assignment: [],
+    isLoading: false,
+    isFetched: false, // 데이터를 이미 불러왔는지 확인하는 플래그
 
   // API 통신으로 과제 불러오기
   fetchAssignments: async () => {
@@ -24,9 +26,11 @@ const useAssignmentStore = create((set, get) => ({
           isSubmitted: item.status.includes('제출 완료'),
           source: 'lms'
         }));
-        
+
+        // 로컬에 저장된 user 과제 유지하기 위한 로컬스토리지
+        const userAssignments = get().assignment.filter(item => item.source === 'user');
         // 데이터 저장 및 호출 완료 플래그 설정
-        set({ assignment: fetchedData, isFetched: true });
+        set({ assignment: [...fetchedData, ...userAssignments], isFetched: true });
       } else {
         console.error("데이터를 불러오지 못했습니다:", result.message);
       } 
@@ -53,6 +57,14 @@ const useAssignmentStore = create((set, get) => ({
       item.id === id ? { ...item, isSubmitted: !item.isSubmitted } : item
     )
   }))
-}));
-
+}),
+    {
+      name: 'assignment-storage',
+      // user 과제만 저장, 새로고침마다 LMS 갱신
+      partialize: (state) => ({
+        assignment: state.assignment.filter(item => item.source === 'user')
+      }),
+    }
+  )
+);
 export default useAssignmentStore;

--- a/client/src/store/useAssignmentStore.js
+++ b/client/src/store/useAssignmentStore.js
@@ -27,10 +27,11 @@ const useAssignmentStore = create(persist(
           source: 'lms'
         }));
 
-        // 로컬에 저장된 user 과제 유지하기 위한 로컬스토리지
-        const userAssignments = get().assignment.filter(item => item.source === 'user');
         // 데이터 저장 및 호출 완료 플래그 설정
-        set({ assignment: [...fetchedData, ...userAssignments], isFetched: true });
+        set((state) => ({
+        assignment: [...fetchedData, ...state.assignment.filter(a => a.source === 'user')], // get()에서 콜백 방식으로 수정
+        isFetched: true
+      }));
       } else {
         console.error("데이터를 불러오지 못했습니다:", result.message);
       } 


### PR DESCRIPTION
**작업내용**

- 과제 상세보기 기능(목데이터이용) 구현
- 과제탭 로컬스토리지 구현 : 새로고침하는 경우, 생성한 과제가 남아있도록 함
<img width="1540" height="988" alt="image" src="https://github.com/user-attachments/assets/d0db746e-7433-4bd7-91f8-27bcd5253148" />





**미구현** 
- 캘린더 다크모드 대응: 다크모드 적용 시 캘린더 라이브러리 스타일 깨짐 현상 수정 필요
- 모달(과제 삭제/상세보기) 중앙 정렬: 과제 삭제 창 및 상세보기 창이 현재 뷰포트의 중앙에 오도록 레이아웃 수정 필요
(도와주세요...)



**관련 이슈**
#33 
#32 
#30