### PR TITLE
feature_assignment-detail_sub: 캘린더 테마 버그 및 모달 위치 수정

### DIFF
--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -257,11 +257,13 @@
   background: var(--bg-card); 
   color: var(--text-main);       
   outline: none;
+  color-scheme: light;
 }
 
 [data-theme='dark'] .input-field input {
   border-color: #707070;
   background: #0e0e0e;
+  color-scheme: dark;
 }
 
 /* 과제 생성 캘린더 영역 */
@@ -271,7 +273,7 @@
 }
 
 [data-theme='dark'] .input-field input[type="datetime-local"]::-webkit-calendar-picker-indicator {
-  filter: invert(1); 
+  filter: none; 
   cursor: pointer;
 }
 

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -1,4 +1,5 @@
 import React, {useState, useMemo, useEffect} from 'react';
+import { createPortal } from 'react-dom';
 import './AssignmentTab.css';
 import useAssignmentStore from '../../store/useAssignmentStore';
 import AssignmentDetail from './AssignmentDetail';
@@ -251,21 +252,26 @@ function AssignmentTab() {
             ))}
       </ul>
     )}
-      {showModal && (<div className="modal-overlay">
-          <div className="modal"><p>과제를 삭제하시겠습니까?</p>
+      {showModal && createPortal(
+        <div className="modal-overlay">
+          <div className="modal">
+            <p>과제를 삭제하시겠습니까?</p>
             <div className="modal-buttons">
-            <button onClick={confirmDelete}>삭제</button>
-            <button onClick={() => setShowModal(false)}>취소</button>
+              <button onClick={confirmDelete}>삭제</button>
+              <button onClick={() => setShowModal(false)}>취소</button>
             </div>
-          </div >
-        </div>)}
+          </div>
+        </div>,
+        document.body
+      )}
         
-        {selectedAssignment && (
+        {selectedAssignment && createPortal(
           <AssignmentDetail
             assignment={selectedAssignment}
             onClose={() => setSelectedAssignment(null)}
-            />
-      )}
+          />,
+          document.body
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
### 작업내용

1. 커스텀 과제 생성 섹터의 캘린더 아이콘이 브라우저 환경의 다크 모드에서 검은색으로 나타나 눈에 띄지 않던 문제를 해결했습니다.
추가로 실제 캘린더가 다크모드 브라우저에서 페이지를 라이트모드로 변경하더라도 캘린더가 다크모드로 출력되는 문제를 해결했습니다.
- Closes [캘린더 아이콘 버그](https://github.com/KadenID/OSBP_Team_NULL/issues/33)

</br>

2. [과제 삭제 모달 위치 변경 오류](https://github.com/KadenID/OSBP_Team_NULL/issues/25)에서 수정되지 않았던 '모달이 전체 layout 중앙에 고정되는 문제'를 해결했습니다.
이제 모달은 현재 screen 중앙에 표시됩니다.