### PR TITLE
feature_login-page : 로그인 페이지 구현 

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
+import LoginPage from "./Components/login_page/LoginPage";
 import MainPage from "./Components/main_page/MainPage";
 import MyPage from "./Components/my_page/MyPage";
 
@@ -8,7 +9,8 @@ function App() {
   return (
     <Router>
       <Routes>
-        <Route path="/" element={<MainPage />} />
+        <Route path="/" element={<LoginPage />} />
+        <Route path="/main" element={<MainPage />} />
         <Route path="/mypage" element={<MyPage />} />
       </Routes>
     </Router>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from "react";
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
 import LoginPage from "./Components/login_page/LoginPage";
@@ -6,12 +6,14 @@ import MainPage from "./Components/main_page/MainPage";
 import MyPage from "./Components/my_page/MyPage";
 
 function App() {
+  const [accessToken, setAccessToken] = useState(null);
+  
   return (
     <Router>
       <Routes>
-        <Route path="/" element={<LoginPage />} />
-        <Route path="/main" element={<MainPage />} />
-        <Route path="/mypage" element={<MyPage />} />
+        <Route path="/" element={<LoginPage onLogin={setAccessToken} />} />
+        <Route path="/main" element={<MainPage accessToken={accessToken} />} />
+        <Route path="/mypage" element={<MyPage accessToken={accessToken} />} />
       </Routes>
     </Router>
   );

--- a/client/src/Components/login_page/LoginPage.css
+++ b/client/src/Components/login_page/LoginPage.css
@@ -23,8 +23,8 @@
   justify-content: center;
   padding: 32px 20px;
   box-sizing: border-box;
-  background: var(--login-bg);
   overflow: hidden;
+  background: var(--login-bg);
   font-family: "Noto Sans CJK KR", "Noto Sans KR", system-ui, sans-serif;
 }
 
@@ -59,4 +59,103 @@
   margin: 10px 0 0;
   color: var(--login-sub-text);
   font-size: 15px;
+}
+
+.login-form,
+.login-field {
+  display: flex;
+  flex-direction: column;
+}
+
+.login-form {
+  gap: 16px;
+}
+
+.login-field {
+  gap: 8px;
+}
+
+.login-field label {
+  color: var(--login-label-text);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.login-field input {
+  height: 48px;
+  border: 1px solid var(--login-input-border);
+  border-radius: 12px;
+  padding: 0 14px;
+  color: var(--login-text);
+  font-size: 15px;
+  background: var(--login-input-bg);
+  outline: none;
+}
+
+.login-field input:focus {
+  border-color: var(--login-primary);
+  box-shadow: 0 0 0 4px var(--login-focus-shadow);
+}
+
+.remember-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--login-muted-text);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.remember-row input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--login-primary);
+}
+
+.login-button {
+  width: 100%;
+  height: 52px;
+  margin-top: 6px;
+  border: none;
+  border-radius: 14px;
+  background: var(--login-primary);
+  color: var(--login-white);
+  font-size: 16px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-button:not(:disabled):hover {
+  background: var(--login-primary-hover);
+  box-shadow: 0 10px 22px var(--login-button-shadow);
+  transform: translateY(-1px);
+}
+
+.login-button:not(:disabled):active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.login-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.login-error {
+  margin: -4px 0 0;
+  color: var(--login-error);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .login-card {
+    padding: 28px 22px;
+    border-radius: 20px;
+  }
+
+  .login-title-area h1 {
+    font-size: 26px;
+  }
 }

--- a/client/src/Components/login_page/LoginPage.css
+++ b/client/src/Components/login_page/LoginPage.css
@@ -1,0 +1,28 @@
+.login-page {
+  --login-bg: #f7f7fb;
+  --login-card-bg: #ffffff;
+  --login-primary: #2196f3;
+  --login-primary-hover: #1687e0;
+  --login-text: #222222;
+  --login-sub-text: #6b7280;
+  --login-label-text: #333333;
+  --login-muted-text: #555555;
+  --login-input-bg: #fbfdff;
+  --login-input-border: #dce5ef;
+  --login-focus-shadow: rgba(33, 150, 243, 0.12);
+  --login-button-shadow: rgba(33, 150, 243, 0.25);
+  --login-card-shadow: rgba(20, 40, 70, 0.1);
+  --login-error: #e53935;
+  --login-white: #ffffff;
+
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 20px;
+  box-sizing: border-box;
+  background: var(--login-bg);
+  overflow: hidden;
+}

--- a/client/src/Components/login_page/LoginPage.css
+++ b/client/src/Components/login_page/LoginPage.css
@@ -1,4 +1,5 @@
 .login-page {
+  /* 로그인 페이지 전용 색상 변수 */
   --login-bg: #f7f7fb;
   --login-card-bg: #ffffff;
   --login-primary: #2196f3;
@@ -28,6 +29,7 @@
   font-family: "Noto Sans CJK KR", "Noto Sans KR", system-ui, sans-serif;
 }
 
+/* 로그인 카드 영역 */
 .login-card {
   width: 100%;
   max-width: 460px;
@@ -61,6 +63,7 @@
   font-size: 15px;
 }
 
+/* 로그인 입력 폼 */
 .login-form,
 .login-field {
   display: flex;
@@ -112,6 +115,7 @@
   accent-color: var(--login-primary);
 }
 
+/* 로그인 버튼과 상태 표시 */
 .login-button {
   width: 100%;
   height: 52px;
@@ -149,6 +153,7 @@
   font-weight: 600;
 }
 
+/* 모바일 화면 대응 */
 @media (max-width: 480px) {
   .login-card {
     padding: 28px 22px;

--- a/client/src/Components/login_page/LoginPage.css
+++ b/client/src/Components/login_page/LoginPage.css
@@ -10,6 +10,7 @@
   --login-muted-text: #555555;
   --login-input-bg: #fbfdff;
   --login-input-border: #dce5ef;
+  --login-placeholder: #8a94a6;
   --login-focus-shadow: rgba(33, 150, 243, 0.12);
   --login-button-shadow: rgba(33, 150, 243, 0.25);
   --login-card-shadow: rgba(20, 40, 70, 0.1);
@@ -17,11 +18,10 @@
   --login-white: #ffffff;
 
   width: 100%;
-  height: 100vh;
-  height: 100dvh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
   padding: 32px 20px;
   box-sizing: border-box;
   overflow: hidden;
@@ -31,9 +31,8 @@
 
 /* 로그인 카드 영역 */
 .login-card {
-  width: 100%;
-  max-width: 460px;
-  padding: 40px;
+  width: min(100%, 430px);
+  padding: 38px 36px;
   border-radius: 24px;
   background: var(--login-card-bg);
   box-shadow: 0 24px 60px var(--login-card-shadow);
@@ -93,6 +92,10 @@
   font-size: 15px;
   background: var(--login-input-bg);
   outline: none;
+}
+
+.login-field input::placeholder {
+  color: var(--login-placeholder);
 }
 
 .login-field input:focus {
@@ -155,12 +158,60 @@
 
 /* 모바일 화면 대응 */
 @media (max-width: 480px) {
+  .login-page {
+    padding: 24px 18px;
+  }
+
   .login-card {
-    padding: 28px 22px;
+    width: min(100%, 340px);
+    padding: 30px 24px;
     border-radius: 20px;
   }
 
+  .login-title-area {
+    margin-bottom: 24px;
+  }
+
+  .login-label {
+    font-size: 13px;
+  }
+
   .login-title-area h1 {
-    font-size: 26px;
+    font-size: 28px;
+  }
+
+  .login-title-area p:last-child {
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .login-field input {
+    height: 50px;
+  }
+
+  .login-button {
+    height: 52px;
+  }
+}
+
+/* 다크 모드 색상 변수 */
+@media (prefers-color-scheme: dark) {
+  .login-page {
+    --login-bg: #1e2430;
+    --login-card-bg: #2a3142;
+    --login-primary: #60a5fa;
+    --login-primary-hover: #3b82f6;
+    --login-text: #f3f4f6;
+    --login-sub-text: #c4c7cf;
+    --login-label-text: #f3f4f6;
+    --login-muted-text: #c2c8d1;
+    --login-input-bg: #242c3b;
+    --login-input-border: #465168;
+    --login-placeholder: #8f9bad;
+    --login-focus-shadow: rgba(96, 165, 250, 0.22);
+    --login-button-shadow: rgba(96, 165, 250, 0.25);
+    --login-card-shadow: rgba(0, 0, 0, 0.28);
+    --login-error: #ff7b7b;
+    --login-white: #ffffff;
   }
 }

--- a/client/src/Components/login_page/LoginPage.css
+++ b/client/src/Components/login_page/LoginPage.css
@@ -25,4 +25,38 @@
   box-sizing: border-box;
   background: var(--login-bg);
   overflow: hidden;
+  font-family: "Noto Sans CJK KR", "Noto Sans KR", system-ui, sans-serif;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 460px;
+  padding: 40px;
+  border-radius: 24px;
+  background: var(--login-card-bg);
+  box-shadow: 0 24px 60px var(--login-card-shadow);
+}
+
+.login-title-area {
+  margin-bottom: 28px;
+}
+
+.login-label {
+  margin: 0 0 10px;
+  color: var(--login-primary);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.login-title-area h1 {
+  margin: 0;
+  color: var(--login-text);
+  font-size: 30px;
+  font-weight: 800;
+}
+
+.login-title-area p:last-child {
+  margin: 10px 0 0;
+  color: var(--login-sub-text);
+  font-size: 15px;
 }

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -5,6 +5,8 @@ import "./LoginPage.css";
 const API_BASE_URL =
     import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
 
+const REMEMBERED_STUDENT_ID_KEY = "rememberedStudentId";
+
 const loginFields = [
     {
         id: "student_id",
@@ -25,14 +27,14 @@ const loginFields = [
 function LoginPage({ onLogin }) {
     const navigate = useNavigate();
 
-    const rememberedStudentId = localStorage.getItem("rememberedStudentId") || "";
-
-    const [loginForm, setLoginForm] = useState({
-        student_id: rememberedStudentId,
+    const [loginForm, setLoginForm] = useState(() => ({
+        student_id: localStorage.getItem(REMEMBERED_STUDENT_ID_KEY) || "",
         password: "",
-    });
+    }));
 
-    const [rememberId, setRememberId] = useState(Boolean(rememberedStudentId));
+    const [rememberId, setRememberId] = useState(() =>
+        Boolean(localStorage.getItem(REMEMBERED_STUDENT_ID_KEY))
+    );
     const [errorMessage, setErrorMessage] = useState("");
     const [isLoading, setIsLoading] = useState(false);
 
@@ -85,9 +87,9 @@ function LoginPage({ onLogin }) {
             }
 
             if (rememberId) {
-                localStorage.setItem("rememberedStudentId", student_id);
+                localStorage.setItem(REMEMBERED_STUDENT_ID_KEY, student_id);
             } else {
-                localStorage.removeItem("rememberedStudentId");
+                localStorage.removeItem(REMEMBERED_STUDENT_ID_KEY);
             }
 
             onLogin?.(data.access_token);

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import "./LoginPage.css";
+
+const API_BASE_URL =
+    import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
 
 const loginFields = [
     {
@@ -18,13 +22,16 @@ const loginFields = [
     },
 ];
 
-function LoginPage() {
+function LoginPage({ onLogin }) {
+    const navigate = useNavigate();
+
     const [loginForm, setLoginForm] = useState({
         student_id: "",
         password: "",
     });
 
     const [errorMessage, setErrorMessage] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
 
     const handleChange = (e) => {
         const { name, value } = e.target;
@@ -35,49 +42,91 @@ function LoginPage() {
         }));
     };
 
-    const handleLogin = (e) => {
+    const handleLogin = async (e) => {
         e.preventDefault();
 
-        if (!loginForm.student_id.trim() || !loginForm.password.trim()) {
-        setErrorMessage("아이디와 비밀번호를 입력해주세요.");
-        return;
+        const student_id = loginForm.student_id.trim();
+        const password = loginForm.password.trim();
+
+        if (!student_id || !password) {
+            setErrorMessage("아이디와 비밀번호를 입력해주세요.");
+            return;
         }
 
-        setErrorMessage("");
-    };
-    
-    return (
-    <main className="login-page">
-        <section className="login-card">
-            <div className="login-title-area">
-                <p className="login-label">충북대 LMS 학습 대시보드</p>
-                <h1>로그인</h1>
-                <p>과제와 공지사항을 확인하려면 로그인해주세요.</p>
-            </div>
+        try {
+            setIsLoading(true);
+            setErrorMessage("");
 
-            <form className="login-form" onSubmit={handleLogin}>
-                {loginFields.map((field) => (
-                <div className="login-field" key={field.id}>
-                    <label htmlFor={field.id}>{field.label}</label>
-                    <input
-                        id={field.id}
-                        name={field.name}
-                        type={field.type}
-                        placeholder={field.placeholder}
-                        value={loginForm[field.name]}
-                        onChange={handleChange}
-                    />
+            const response = await fetch(`${API_BASE_URL}/auth/login`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                credentials: "include",
+                body: JSON.stringify({
+                    student_id,
+                    password,
+                }),
+            });
+
+            const data = await response.json();
+
+            if (!response.ok) {
+                setErrorMessage(data.detail || "로그인에 실패했습니다.");
+                return;
+            }
+
+            if (!data.access_token) {
+                setErrorMessage("Access Token을 받지 못했습니다.");
+                return;
+            }
+
+            onLogin?.(data.access_token);
+            navigate("/main");
+        } catch (error) {
+            setErrorMessage("서버에 연결할 수 없습니다.");
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <main className="login-page">
+            <section className="login-card">
+                <div className="login-title-area">
+                    <p className="login-label">충북대 LMS 학습 대시보드</p>
+                    <h1>로그인</h1>
+                    <p>과제와 공지사항을 확인하려면 로그인해주세요.</p>
                 </div>
-                ))}
-            
-                {errorMessage && <p className="login-error">{errorMessage}</p>}
-            
-                <button type="submit" className="login-button">
-                    로그인
-                </button>
-            </form>
-        </section>
-    </main>
+
+                <form className="login-form" onSubmit={handleLogin}>
+                    {loginFields.map((field) => (
+                        <div className="login-field" key={field.id}>
+                            <label htmlFor={field.id}>{field.label}</label>
+                            <input
+                                id={field.id}
+                                name={field.name}
+                                type={field.type}
+                                placeholder={field.placeholder}
+                                value={loginForm[field.name]}
+                                onChange={handleChange}
+                                autoComplete={
+                                    field.name === "password"
+                                        ? "current-password"
+                                        : "username"
+                                }
+                            />
+                        </div>
+                    ))}
+
+                    {errorMessage && <p className="login-error">{errorMessage}</p>}
+
+                    <button type="submit" className="login-button" disabled={isLoading}>
+                        {isLoading ? "로그인 중..." : "로그인"}
+                    </button>
+                </form>
+            </section>
+        </main>
     );
 }
 

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -2,13 +2,43 @@ import React from "react";
 import "./LoginPage.css";
 
 function LoginPage() {
-  return (
+    return (
     <main className="login-page">
-      <section className="login-card">
-        <h1>로그인</h1>
-      </section>
+        <section className="login-card">
+            <div className="login-title-area">
+                <p className="login-label">충북대 LMS 학습 대시보드</p>
+                <h1>로그인</h1>
+                <p>과제와 공지사항을 확인하려면 로그인해주세요.</p>
+            </div>
+            
+            <form className="login-form">
+                <div className="login-field">
+                    <label htmlFor="student_id">아이디</label>
+                    <input
+                        id="student_id"
+                        name="student_id"
+                        type="text"
+                        placeholder="아이디를 입력하세요"
+                    />
+                </div>
+                
+                <div className="login-field">
+                    <label htmlFor="password">비밀번호</label>
+                    <input
+                        id="password"
+                        name="password"
+                        type="password"
+                        placeholder="비밀번호를 입력하세요"
+                    />
+                </div>
+
+                <button type="submit" className="login-button">
+                    로그인
+                </button>
+            </form>
+        </section>
     </main>
-  );
+    );
 }
 
 export default LoginPage;

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -15,6 +15,7 @@ const loginFields = [
         label: "아이디",
         type: "text",
         placeholder: "아이디를 입력하세요",
+        autoComplete: "username",
     },
     {
         id: "password",
@@ -22,6 +23,7 @@ const loginFields = [
         label: "비밀번호",
         type: "password",
         placeholder: "비밀번호를 입력하세요",
+        autoComplete: "current-password",
     },
 ];
 
@@ -78,7 +80,7 @@ function LoginPage({ onLogin }) {
         if (isLoading) return;
 
         const student_id = loginForm.student_id.trim();
-        const password = loginForm.password.trim();
+        const password = loginForm.password;
 
         if (!student_id || !password) {
             setErrorMessage("아이디와 비밀번호를 입력해주세요.");
@@ -151,11 +153,8 @@ function LoginPage({ onLogin }) {
                                 placeholder={field.placeholder}
                                 value={loginForm[field.name]}
                                 onChange={handleChange}
-                                autoComplete={
-                                    field.name === "password"
-                                        ? "current-password"
-                                        : "username"
-                                }
+                                autoComplete={field.autoComplete}
+                                disabled={isLoading}
                             />
                         </div>
                     ))}

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -1,7 +1,51 @@
-import React from "react";
+import React, { useState } from "react";
 import "./LoginPage.css";
 
+const loginFields = [
+    {
+        id: "student_id",
+        name: "student_id",
+        label: "아이디",
+        type: "text",
+        placeholder: "아이디를 입력하세요",
+    },
+    {
+        id: "password",
+        name: "password",
+        label: "비밀번호",
+        type: "password",
+        placeholder: "비밀번호를 입력하세요",
+    },
+];
+
 function LoginPage() {
+    const [loginForm, setLoginForm] = useState({
+        student_id: "",
+        password: "",
+    });
+
+    const [errorMessage, setErrorMessage] = useState("");
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+
+        setLoginForm((prevForm) => ({
+            ...prevForm,
+            [name]: value,
+        }));
+    };
+
+    const handleLogin = (e) => {
+        e.preventDefault();
+
+        if (!loginForm.student_id.trim() || !loginForm.password.trim()) {
+        setErrorMessage("아이디와 비밀번호를 입력해주세요.");
+        return;
+        }
+
+        setErrorMessage("");
+    };
+    
     return (
     <main className="login-page">
         <section className="login-card">
@@ -10,28 +54,24 @@ function LoginPage() {
                 <h1>로그인</h1>
                 <p>과제와 공지사항을 확인하려면 로그인해주세요.</p>
             </div>
-            
-            <form className="login-form">
-                <div className="login-field">
-                    <label htmlFor="student_id">아이디</label>
-                    <input
-                        id="student_id"
-                        name="student_id"
-                        type="text"
-                        placeholder="아이디를 입력하세요"
-                    />
-                </div>
-                
-                <div className="login-field">
-                    <label htmlFor="password">비밀번호</label>
-                    <input
-                        id="password"
-                        name="password"
-                        type="password"
-                        placeholder="비밀번호를 입력하세요"
-                    />
-                </div>
 
+            <form className="login-form" onSubmit={handleLogin}>
+                {loginFields.map((field) => (
+                <div className="login-field" key={field.id}>
+                    <label htmlFor={field.id}>{field.label}</label>
+                    <input
+                        id={field.id}
+                        name={field.name}
+                        type={field.type}
+                        placeholder={field.placeholder}
+                        value={loginForm[field.name]}
+                        onChange={handleChange}
+                    />
+                </div>
+                ))}
+            
+                {errorMessage && <p className="login-error">{errorMessage}</p>}
+            
                 <button type="submit" className="login-button">
                     로그인
                 </button>

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import "./LoginPage.css";
+
+function LoginPage() {
+  return (
+    <main className="login-page">
+      <section className="login-card">
+        <h1>로그인</h1>
+      </section>
+    </main>
+  );
+}
+
+export default LoginPage;

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -25,11 +25,14 @@ const loginFields = [
 function LoginPage({ onLogin }) {
     const navigate = useNavigate();
 
+    const rememberedStudentId = localStorage.getItem("rememberedStudentId") || "";
+
     const [loginForm, setLoginForm] = useState({
-        student_id: "",
+        student_id: rememberedStudentId,
         password: "",
     });
 
+    const [rememberId, setRememberId] = useState(Boolean(rememberedStudentId));
     const [errorMessage, setErrorMessage] = useState("");
     const [isLoading, setIsLoading] = useState(false);
 
@@ -81,6 +84,12 @@ function LoginPage({ onLogin }) {
                 return;
             }
 
+            if (rememberId) {
+                localStorage.setItem("rememberedStudentId", student_id);
+            } else {
+                localStorage.removeItem("rememberedStudentId");
+            }
+
             onLogin?.(data.access_token);
             navigate("/main");
         } catch (error) {
@@ -118,6 +127,15 @@ function LoginPage({ onLogin }) {
                             />
                         </div>
                     ))}
+
+                    <label className="remember-row">
+                        <input
+                            type="checkbox"
+                            checked={rememberId}
+                            onChange={(e) => setRememberId(e.target.checked)}
+                        />
+                        <span>아이디 기억하기</span>
+                    </label>
 
                     {errorMessage && <p className="login-error">{errorMessage}</p>}
 

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -45,6 +45,10 @@ function LoginPage({ onLogin }) {
             ...prevForm,
             [name]: value,
         }));
+
+        if (errorMessage) {
+            setErrorMessage("");
+        }
     };
 
     const clearPassword = () => {
@@ -63,9 +67,9 @@ function LoginPage({ onLogin }) {
     };
 
     const handleLogin = async (e) => {
-        if (isLoading) return;
-
         e.preventDefault();
+
+        if (isLoading) return;
 
         const student_id = loginForm.student_id.trim();
         const password = loginForm.password.trim();
@@ -101,7 +105,7 @@ function LoginPage({ onLogin }) {
 
             if (!data?.access_token) {
                 clearPassword();
-                setErrorMessage("Access Token을 받지 못했습니다.");
+                setErrorMessage("로그인 응답을 확인할 수 없습니다. 다시 시도해주세요.");
                 return;
             }
 

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -6,6 +6,7 @@ const API_BASE_URL =
     import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
 
 const REMEMBERED_STUDENT_ID_KEY = "rememberedStudentId";
+const MAX_LOGIN_INPUT_LENGTH = 20;
 
 // 로그인 폼에서 렌더링할 입력 필드 목록
 const loginFields = [
@@ -16,6 +17,7 @@ const loginFields = [
         type: "text",
         placeholder: "아이디를 입력하세요",
         autoComplete: "username",
+        maxLength: MAX_LOGIN_INPUT_LENGTH,
     },
     {
         id: "password",
@@ -24,6 +26,7 @@ const loginFields = [
         type: "password",
         placeholder: "비밀번호를 입력하세요",
         autoComplete: "current-password",
+        maxLength: MAX_LOGIN_INPUT_LENGTH,
     },
 ];
 
@@ -84,6 +87,15 @@ function LoginPage({ onLogin }) {
 
         if (!student_id || !password) {
             setErrorMessage("아이디와 비밀번호를 입력해주세요.");
+            return;
+        }
+
+        if (
+            student_id.length > MAX_LOGIN_INPUT_LENGTH ||
+            password.length > MAX_LOGIN_INPUT_LENGTH
+        ) {
+            setErrorMessage("아이디와 비밀번호는 20자 이하로 입력해주세요.");
+            clearPassword();
             return;
         }
 
@@ -154,6 +166,7 @@ function LoginPage({ onLogin }) {
                                 value={loginForm[field.name]}
                                 onChange={handleChange}
                                 autoComplete={field.autoComplete}
+                                maxLength={field.maxLength}
                                 disabled={isLoading}
                             />
                         </div>

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -137,7 +137,7 @@ function LoginPage({ onLogin }) {
                 <div className="login-title-area">
                     <p className="login-label">충북대 LMS 학습 대시보드</p>
                     <h1>로그인</h1>
-                    <p>과제와 공지사항을 확인하려면 로그인해주세요.</p>
+                    <p>학습 대시보드를 이용하려면 로그인해주세요.</p>
                 </div>
 
                 <form className="login-form" onSubmit={handleLogin}>

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -7,6 +7,7 @@ const API_BASE_URL =
 
 const REMEMBERED_STUDENT_ID_KEY = "rememberedStudentId";
 
+// 로그인 폼에서 렌더링할 입력 필드 목록
 const loginFields = [
     {
         id: "student_id",
@@ -27,6 +28,7 @@ const loginFields = [
 function LoginPage({ onLogin }) {
     const navigate = useNavigate();
 
+    // 저장된 아이디가 있으면 로그인 폼 초기값으로 사용
     const [loginForm, setLoginForm] = useState(() => ({
         student_id: localStorage.getItem(REMEMBERED_STUDENT_ID_KEY) || "",
         password: "",
@@ -38,6 +40,7 @@ function LoginPage({ onLogin }) {
     const [errorMessage, setErrorMessage] = useState("");
     const [isLoading, setIsLoading] = useState(false);
 
+    // 입력값 변경 시 로그인 폼 상태를 갱신
     const handleChange = (e) => {
         const { name, value } = e.target;
 
@@ -51,6 +54,7 @@ function LoginPage({ onLogin }) {
         }
     };
 
+    // 로그인 실패 시 비밀번호 입력값만 초기화
     const clearPassword = () => {
         setLoginForm((prevForm) => ({
             ...prevForm,
@@ -58,6 +62,7 @@ function LoginPage({ onLogin }) {
         }));
     };
 
+    // 서버 응답이 JSON이 아닐 경우를 대비해 안전하게 파싱
     const parseLoginResponse = async (response) => {
         try {
             return await response.json();
@@ -66,6 +71,7 @@ function LoginPage({ onLogin }) {
         }
     };
 
+    // 백엔드 로그인 API 호출 후 성공 시 메인 페이지로 이동
     const handleLogin = async (e) => {
         e.preventDefault();
 

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -47,6 +47,14 @@ function LoginPage({ onLogin }) {
         }));
     };
 
+    const parseLoginResponse = async (response) => {
+        try {
+            return await response.json();
+        } catch {
+            return null;
+        }
+    };
+
     const handleLogin = async (e) => {
         e.preventDefault();
 
@@ -73,15 +81,15 @@ function LoginPage({ onLogin }) {
                     password,
                 }),
             });
-
-            const data = await response.json();
+                  
+            const data = await parseLoginResponse(response);
 
             if (!response.ok) {
-                setErrorMessage(data.detail || "로그인에 실패했습니다.");
+                setErrorMessage(data?.detail || "로그인에 실패했습니다.");
                 return;
             }
 
-            if (!data.access_token) {
+            if (!data?.access_token) {
                 setErrorMessage("Access Token을 받지 못했습니다.");
                 return;
             }

--- a/client/src/Components/login_page/LoginPage.jsx
+++ b/client/src/Components/login_page/LoginPage.jsx
@@ -47,6 +47,13 @@ function LoginPage({ onLogin }) {
         }));
     };
 
+    const clearPassword = () => {
+        setLoginForm((prevForm) => ({
+            ...prevForm,
+            password: "",
+        }));
+    };
+
     const parseLoginResponse = async (response) => {
         try {
             return await response.json();
@@ -56,6 +63,8 @@ function LoginPage({ onLogin }) {
     };
 
     const handleLogin = async (e) => {
+        if (isLoading) return;
+
         e.preventDefault();
 
         const student_id = loginForm.student_id.trim();
@@ -81,15 +90,17 @@ function LoginPage({ onLogin }) {
                     password,
                 }),
             });
-                  
+
             const data = await parseLoginResponse(response);
 
             if (!response.ok) {
+                clearPassword();
                 setErrorMessage(data?.detail || "로그인에 실패했습니다.");
                 return;
             }
 
             if (!data?.access_token) {
+                clearPassword();
                 setErrorMessage("Access Token을 받지 못했습니다.");
                 return;
             }
@@ -103,6 +114,7 @@ function LoginPage({ onLogin }) {
             onLogin?.(data.access_token);
             navigate("/main");
         } catch (error) {
+            clearPassword();
             setErrorMessage("서버에 연결할 수 없습니다.");
         } finally {
             setIsLoading(false);

--- a/client/src/Components/my_page/MyPage.jsx
+++ b/client/src/Components/my_page/MyPage.jsx
@@ -45,7 +45,7 @@ function MyPage() {
                 <div className="mypage-title-row">
                     <h1 className="mypage-title">마이페이지</h1>
                     
-                    <button type="button" className="main-button" onClick={() => navigate("/")}>
+                    <button type="button" className="main-button" onClick={() => navigate("/main")}>
                         <FiHome className="main-icon" />
                         메인
                     </button>


### PR DESCRIPTION
## 개요

로그인 페이지를 구현하고 백엔드 인증 API와 연동했습니다. 로그인 성공 시 Access Token을 메모리 상태에 저장하고 메인 페이지로 이동하도록 처리했습니다.

## 작업 내용

- 로그인 페이지 UI 구현 및 반응형/다크모드 스타일 적용
- 학번, 비밀번호 입력 상태 및 에러 메시지 처리
- /auth/login API 연동 및 쿠키 포함 요청 처리
- 로그인 성공 시 Access Token을 App state에 저장
- 아이디 기억하기 기능 추가
- 로그인 중 입력 비활성화 및 실패 시 비밀번호 초기화 처리

<img width="1473" height="716" alt="로그인화면" src="https://github.com/user-attachments/assets/55f66795-219f-4c4f-a10d-a6ee04fce34f" />

## 관련 이슈
#40  