### PR TITLE
Feature mainpage : 메인 페이지 UI 개선

### DIFF
--- a/client/src/Components/assignment-tab/AssignmentDetail.jsx
+++ b/client/src/Components/assignment-tab/AssignmentDetail.jsx
@@ -1,17 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import './AssignmentDetail.css';
 
+const DESCRIPTION_MAX_LENGTH = 1000;
+
 function AssignmentDetail({ assignment, onClose, updateDescription, accessToken }) {
 
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState("");
 
+  if (!assignment) return null;
+
   // 객체 직접 참조
   const description = assignment.source === 'lms'
     ? "현재 상세 설명을 불러올 수 없습니다.\nLMS 페이지에서 직접 확인해주세요."
     : (assignment.description ?? "");
-
-  if (!assignment) return null;
 
   // 생성 과제 편집
   const handleEditStart = () => {
@@ -21,6 +23,8 @@ function AssignmentDetail({ assignment, onClose, updateDescription, accessToken 
 
   // 생성 과제 저장
   const handleSave = () => {
+    if (editText.length > DESCRIPTION_MAX_LENGTH) return;
+
     updateDescription(assignment.id, editText, accessToken);
     setIsEditing(false);
   };
@@ -65,6 +69,7 @@ function AssignmentDetail({ assignment, onClose, updateDescription, accessToken 
               onChange={(e) => setEditText(e.target.value)}
               placeholder="과제 상세 설명을 입력하세요..."
               autoFocus
+              maxLength={DESCRIPTION_MAX_LENGTH}
             />
             <div className="edit-actions">
               <button className="save-btn" onClick={handleSave}>저장</button>

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -82,6 +82,7 @@
 .info {
   min-width: 0;
   flex: 1;
+  padding-right: 24px;
 }
 
 .subject {
@@ -107,7 +108,7 @@
   gap: 5px; 
   text-align: right;
   flex-shrink: 0;
-  margin-left: auto;
+  margin-left: 16px;
 }
 
 /* 제출 상태 라벨 */
@@ -521,11 +522,15 @@ body.modal-open .left:hover {
 }
 
 @media screen and (max-width: 768px) {
+  .info {
+    width: 100%;
+    padding-right: 0;
+  }
+
   .assignment-item {
     padding: 12px;
     flex-direction: column;
     align-items: flex-start;
-    height: auto; 
     gap: 10px;
   }
 

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -26,7 +26,6 @@
   flex-wrap: wrap;
   align-items: center;
   padding: 11px;
-  height: 110px;
   min-width: 0;
   min-height: 150px;
   background-color: var(--bg-card); 
@@ -80,9 +79,16 @@
 }
 
 /* 과목 */
+.info {
+  min-width: 0;
+  flex: 1;
+}
+
 .subject {
   font-size: 0.8rem;
   color: var(--text-main);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* 과제명 */
@@ -90,6 +96,8 @@
   font-weight: 600;
   margin: 5px 0 0 0;
   color: var(--text-main);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .status-box {
@@ -98,7 +106,8 @@
   align-items: flex-end; 
   gap: 5px; 
   text-align: right;
-  flex-shrink: 0;  
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 /* 제출 상태 라벨 */
@@ -444,6 +453,14 @@
   white-space: nowrap;
 }
 
+.add-form-error {
+  width: 100%;
+  margin: -4px 0 0;
+  color: #ff4d4f;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
 /* 생성 과제 삭제창 */
 .modal-overlay {
   position: fixed;
@@ -523,7 +540,6 @@ body.modal-open .left:hover {
 
 @media screen and (max-width: 1300px) {
   .assignment-item {
-    height: auto;        /* 고정 높이 해제 */
     min-height: 110px;
   }
 }

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -141,10 +141,9 @@
   align-items: center;
   gap: 10px;
   margin-bottom: 20px;
-  padding: 10px;
-  background-color: var(--bg-layout);
+  padding: 0;
+  background: transparent;
   color: var(--text-main);
-  border-radius: 8px;
 }
 
 .tag-container p {
@@ -155,11 +154,11 @@
 }
 
 .tag-container button {
+  height: 34px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   color: var(--text-main);
-
-  padding: 6px 14px;
+  padding: 0 14px;
   border-radius: 15px;
   cursor: pointer;
   font-size: 0.85rem;
@@ -223,13 +222,13 @@
 .add-form {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
   gap: 12px;
-  background-color: var(--bg-card);
-  padding: 12px;
-  border-radius: 12px;
-  border: 1px solid var(--border);
+  padding: 0;
   margin-bottom: 17px;
+  background: transparent;
+  border: none;
+  border-radius: 0;
 }
 
 .input-group {
@@ -237,14 +236,15 @@
   flex-wrap: wrap;
   flex: 1;
   gap: 10px;
+  align-items: center;
 }
 
 .input-field {
   display: flex;
-  flex-wrap: wrap;
   flex-direction: column;
   flex: 1;
   gap: 5px;
+  min-width: 140px;
 }
 
 .input-field label {
@@ -255,14 +255,17 @@
 }
 
 .input-field input {
-  padding: 8px 9px;
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
   border: 1px solid var(--border);
   border-radius: 8px;
   font-size: 13px;
-  background: var(--bg-card); 
-  color: var(--text-main);       
+  background: var(--bg-card);
+  color: var(--text-main);
   outline: none;
   color-scheme: light;
+  box-sizing: border-box;
 }
 
 [data-theme='dark'] .input-field input {
@@ -283,7 +286,7 @@
 }
 
 .add-submit-btn {
-  height: 32px;
+  height: 36px;
   padding: 0 15px;
   background-color: #1890ff;
   color: white;

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -256,7 +256,7 @@
 
 .input-field input {
   width: 100%;
-  height: 36px;
+  height: 42px;
   padding: 0 10px;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -275,18 +275,164 @@
 }
 
 /* 과제 생성 캘린더 영역 */
-.input-field input[type="datetime-local"]::-webkit-calendar-picker-indicator {
-  filter: invert(0.5); 
+.deadline-field {
+  flex: 0 0 325px;
+  min-width: 325px;
+}
+
+.deadline-control {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 42px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  box-sizing: border-box;
+}
+
+.deadline-control input[type="date"],
+.deadline-control .time-input {
+  height: 100%;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-main);
+  font-size: 14px;
+  line-height: 42px;
+  outline: none;
+  box-shadow: none;
+  box-sizing: border-box;
+}
+
+.deadline-control input[type="date"] {
+  flex: 1;
+  min-width: 0;
+}
+
+.deadline-control .time-input {
+  width: 56px;
+  text-align: center;
+}
+
+.input-field .deadline-control .time-input {
+  width: 56px;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.time-picker-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  width: 86px;
+  flex: none;
+}
+
+.time-picker-toggle {
+  width: 22px;
+  height: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+  padding: 0;
+}
+
+.time-picker-toggle::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  border-right: 1.5px solid var(--text-main);
+  border-bottom: 1.5px solid var(--text-main);
+  transform: translate(-50%, -65%) rotate(45deg);
+}
+
+.deadline-control input:focus,
+.time-picker-toggle:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.time-picker-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 100;
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
+}
+
+.time-column {
+  width: 48px;
+  max-height: 180px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: #b8b8b8 transparent;
+}
+
+.time-column::-webkit-scrollbar {
+  width: 6px;
+}
+
+.time-column::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.time-column::-webkit-scrollbar-thumb {
+  background: #b8b8b8;
+  border-radius: 999px;
+}
+
+.time-column button {
+  width: 100%;
+  height: 28px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-main);
+  font-size: 13px;
   cursor: pointer;
 }
 
-[data-theme='dark'] .input-field input[type="datetime-local"]::-webkit-calendar-picker-indicator {
-  filter: none; 
-  cursor: pointer;
+.time-column button:hover,
+.time-column button.selected {
+  background: #1890ff;
+  color: #fff;
+}
+
+[data-theme='dark'] .time-column {
+  scrollbar-color: #5f5f5f transparent;
+}
+
+[data-theme='dark'] .time-column::-webkit-scrollbar-thumb {
+  background: #5f5f5f;
+}
+
+[data-theme='dark'] .deadline-control,
+[data-theme='dark'] .time-picker-panel {
+  border-color: #707070;
+  background: #0e0e0e;
 }
 
 .add-submit-btn {
-  height: 36px;
+  height: 42px;
   padding: 0 15px;
   background-color: #1890ff;
   color: white;

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -13,8 +13,19 @@ const getTodayDateString = () => {
   return `${year}-${month}-${date}`;
 };
 
+const getMaxDeadlineDateString = () => {
+  const maxDate = new Date();
+  maxDate.setFullYear(maxDate.getFullYear() + 5);
+
+  const year = maxDate.getFullYear();
+  const month = String(maxDate.getMonth() + 1).padStart(2, "0");
+  const date = String(maxDate.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${date}`;
+};
+
 const MIN_DEADLINE_DATE = getTodayDateString();
-const MAX_DEADLINE_DATE = "2099-12-31";
+const MAX_DEADLINE_DATE = getMaxDeadlineDateString();
 
 const STATUS = {
   UNSUBMITTED: 'UNSUBMITTED',
@@ -150,7 +161,7 @@ function AssignmentTab({ accessToken }) {
     }
 
     if (deadlineDate < minDate || deadlineDate > maxDate) {
-      alert("마감 날짜는 오늘부터 2099년 12월 31일까지만 입력할 수 있습니다.");
+      alert("마감 날짜는 오늘부터 5년 이내로 입력할 수 있습니다.");
       return;
     }
 

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -59,7 +59,9 @@ function AssignmentTab({ accessToken }) {
   
   const [newSubject, setNewSubject] = useState("");
   const [newTask, setNewTask] = useState("");
-  const [newDeadline, setNewDeadline] = useState("");
+  const [newDeadlineDate, setNewDeadlineDate] = useState("");
+  const [newDeadlineTime, setNewDeadlineTime] = useState("23:59");
+  const [showTimePicker, setShowTimePicker] = useState(false);
 
   const [activeTags, setActiveTags] = useState([
     STATUS.UNSUBMITTED,
@@ -84,20 +86,58 @@ function AssignmentTab({ accessToken }) {
 
 
   // 과제 추가 로직
+  const formatTimeInput = (value) => {
+  const onlyNumbers = value.replace(/\D/g, "").slice(0, 4);
+
+  if (onlyNumbers.length <= 2) return onlyNumbers;
+
+  return `${onlyNumbers.slice(0, 2)}:${onlyNumbers.slice(2)}`;
+  };
+
+  const handleTimeChange = (e) => {
+    setNewDeadlineTime(formatTimeInput(e.target.value));
+  };
+
+  const handleTimeBlur = () => {
+    setTimeout(() => {
+      const [hour = "", minute = ""] = newDeadlineTime.split(":");
+      const hourNumber = Number(hour);
+      const minuteNumber = Number(minute);
+
+      if (
+        hour.length !== 2 ||
+        minute.length !== 2 ||
+        hourNumber > 23 ||
+        minuteNumber > 59
+      ) {
+        setNewDeadlineTime("23:59");
+        return;
+      }
+
+      setNewDeadlineTime(
+        `${String(hourNumber).padStart(2, "0")}:${String(minuteNumber).padStart(2, "0")}`
+      );
+    }, 100);
+  };
+
   const handleAddAssignment = (e) => {
     e.preventDefault();
 
     const newItem = {
-      id: Date.now(),
-      subject: newSubject,
-      task: newTask,
-      deadline: `${newDeadline}:59`,
-      isSubmitted: false,
-      source: 'user'
-    };
+    id: Date.now(),
+    subject: newSubject,
+    task: newTask,
+    deadline: `${newDeadlineDate}T${newDeadlineTime}:59`,
+    isSubmitted: false,
+    source: 'user'
+  };
 
-    addAssignment(newItem); // store의 추가 액션 호출
-    setNewSubject(""); setNewTask(""); setNewDeadline("");
+  addAssignment(newItem);
+  setNewSubject("");
+  setNewTask("");
+  setNewDeadlineDate("");
+  setNewDeadlineTime("23:59");
+  setShowTimePicker(false);
   };
 
    // 과제 필터링 함수 : processed + filteredList
@@ -184,13 +224,94 @@ function AssignmentTab({ accessToken }) {
             <input type="text" placeholder="할 일" value={newTask} onChange={e => setNewTask(e.target.value)} />
           </div>
 
-          <div className="input-field">
-            <input type="datetime-local" value={newDeadline} onChange={e => setNewDeadline(e.target.value)} required/>
+          <div className="input-field deadline-field">
+            <div className="deadline-control">
+              <input
+                type="date"
+                value={newDeadlineDate}
+                onMouseDown={() => setShowTimePicker(false)}
+                onFocus={() => setShowTimePicker(false)}
+                onChange={e => setNewDeadlineDate(e.target.value)}
+                required
+              />
+
+              <div className="time-picker-wrap">
+                <input
+                  type="text"
+                  className="time-input"
+                  value={newDeadlineTime}
+                  onChange={handleTimeChange}
+                  onBlur={handleTimeBlur}
+                  onFocus={() => setShowTimePicker(true)}
+                  placeholder="23:59"
+                  inputMode="numeric"
+                  maxLength="5"
+                  required
+                />
+
+                <button
+                  type="button"
+                  className="time-picker-toggle"
+                  onMouseDown={e => e.preventDefault()}
+                  onClick={() => setShowTimePicker(prev => !prev)}
+                  aria-label="시간 선택"
+                />
+
+                {showTimePicker && (
+                  <div
+                    className="time-picker-panel"
+                    onMouseDown={e => e.preventDefault()}
+                  >
+                    <div className="time-column">
+                      {Array.from({ length: 24 }, (_, hour) => {
+                        const value = String(hour).padStart(2, "0");
+                        const isSelected = newDeadlineTime.slice(0, 2) === value;
+
+                        return (
+                          <button
+                            type="button"
+                            key={value}
+                            className={isSelected ? "selected" : ""}
+                            onClick={() => {
+                              const minute = newDeadlineTime.slice(3, 5) || "00";
+                              setNewDeadlineTime(`${value}:${minute}`);
+                            }}
+                          >
+                            {value}
+                          </button>
+                        );
+                      })}
+                    </div>
+
+                    <div className="time-column">
+                      {Array.from({ length: 60 }, (_, minute) => {
+                        const value = String(minute).padStart(2, "0");
+                        const isSelected = newDeadlineTime.slice(3, 5) === value;
+
+                        return (
+                          <button
+                            type="button"
+                            key={value}
+                            className={isSelected ? "selected" : ""}
+                            onClick={() => {
+                              const hour = newDeadlineTime.slice(0, 2) || "23";
+                              setNewDeadlineTime(`${hour}:${value}`);
+                              setShowTimePicker(false);
+                            }}
+                          >
+                            {value}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
         </div>
-          
-          <button type="submit" className="add-submit-btn">새 과제 추가</button>
-      </form>
+      <button type="submit" className="add-submit-btn">새 과제 추가</button>
+    </form>
 
         <div className="tag-container"><p>필터</p> {/* 필터링 태그 */}
           {[

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -13,20 +13,14 @@ const getTodayDateString = () => {
   return `${year}-${month}-${date}`;
 };
 
-const getMaxDeadlineDateString = () => {
-  const maxDate = new Date();
-  maxDate.setFullYear(maxDate.getFullYear() + 5);
-
-  const year = maxDate.getFullYear();
-  const month = String(maxDate.getMonth() + 1).padStart(2, "0");
-  const date = String(maxDate.getDate()).padStart(2, "0");
-
-  return `${year}-${month}-${date}`;
-};
 
 // 커스텀 과제 마감일 입력 범위 제한
-const MIN_DEADLINE_DATE = getTodayDateString();
-const MAX_DEADLINE_DATE = getMaxDeadlineDateString();
+const MIN_DEADLINE_DATE = "2000-01-01";
+const MAX_DEADLINE_DATE = "2099-12-31";
+
+// 과목 및 과제 입력 범위 제한
+const SUBJECT_MAX_LENGTH = 30;
+const TASK_MAX_LENGTH = 50;
 
 const STATUS = {
   UNSUBMITTED: 'UNSUBMITTED',
@@ -90,6 +84,7 @@ function AssignmentTab({ accessToken }) {
   const [newDeadlineDate, setNewDeadlineDate] = useState(getTodayDateString);
   const [newDeadlineTime, setNewDeadlineTime] = useState("23:59");
   const [showTimePicker, setShowTimePicker] = useState(false);
+  const [formError, setFormError] = useState("");
 
   const [activeTags, setActiveTags] = useState([
     STATUS.UNSUBMITTED,
@@ -124,66 +119,95 @@ function AssignmentTab({ accessToken }) {
 
   const handleTimeChange = (e) => {
     setNewDeadlineTime(formatTimeInput(e.target.value));
+    if (formError) setFormError("");
+  };
+
+  const normalizeTimeInput = (value) => {
+    const [hour = "", minute = ""] = value.split(":");
+    const hourNumber = Number(hour);
+    const minuteNumber = Number(minute);
+
+    if (
+      hour.length !== 2 ||
+      minute.length !== 2 ||
+      Number.isNaN(hourNumber) ||
+      Number.isNaN(minuteNumber) ||
+      hourNumber < 0 ||
+      minuteNumber < 0 ||
+      hourNumber > 23 ||
+      minuteNumber > 59
+    ) {
+      return "23:59";
+    }
+
+    return `${String(hourNumber).padStart(2, "0")}:${String(minuteNumber).padStart(2, "0")}`;
   };
 
   const handleTimeBlur = () => {
-    setTimeout(() => {
-      const [hour = "", minute = ""] = newDeadlineTime.split(":");
-      const hourNumber = Number(hour);
-      const minuteNumber = Number(minute);
-
-      if (
-        hour.length !== 2 ||
-        minute.length !== 2 ||
-        hourNumber > 23 ||
-        minuteNumber > 59
-      ) {
-        setNewDeadlineTime("23:59");
-        return;
-      }
-
-      setNewDeadlineTime(
-        `${String(hourNumber).padStart(2, "0")}:${String(minuteNumber).padStart(2, "0")}`
-      );
-    }, 100);
+    setNewDeadlineTime((prev) => normalizeTimeInput(prev));
   };
 
   const handleAddAssignment = (e) => {
     e.preventDefault();
 
-    const deadlineValue = `${newDeadlineDate}T${newDeadlineTime}:59`;
+    const trimmedSubject = newSubject.trim();
+    const trimmedTask = newTask.trim();
+
+    if (!trimmedSubject) {
+      setFormError("과목명을 입력해주세요.");
+      return;
+    }
+
+    if (!trimmedTask) {
+      setFormError("할 일을 입력해주세요.");
+      return;
+    }
+
+    if (trimmedSubject.length > SUBJECT_MAX_LENGTH) {
+      setFormError(`과목명은 ${SUBJECT_MAX_LENGTH}자 이하로 입력해주세요.`);
+      return;
+    }
+
+    if (trimmedTask.length > TASK_MAX_LENGTH) {
+      setFormError(`할 일은 ${TASK_MAX_LENGTH}자 이하로 입력해주세요.`);
+      return;
+    }
+
+    const normalizedDeadlineTime = normalizeTimeInput(newDeadlineTime);
+    const deadlineValue = `${newDeadlineDate}T${normalizedDeadlineTime}:59`;
     const deadlineDate = new Date(deadlineValue);
     const minDate = new Date(`${MIN_DEADLINE_DATE}T00:00:00`);
     const maxDate = new Date(`${MAX_DEADLINE_DATE}T23:59:59`);
 
     if (Number.isNaN(deadlineDate.getTime())) {
-      alert("올바른 마감 날짜를 입력해주세요.");
+      setFormError("올바른 마감 날짜를 입력해주세요.");
       return;
     }
 
     if (deadlineDate < minDate || deadlineDate > maxDate) {
-      alert("마감 날짜는 오늘부터 5년 이내로 입력할 수 있습니다.");
+      setFormError("마감 날짜는 2000년 1월 1일부터 2099년 12월 31일까지만 입력할 수 있습니다.");
       return;
     }
 
     const newItem = {
-      subject: newSubject,
-      task: newTask,
+      subject: trimmedSubject,
+      task: trimmedTask,
       deadline: deadlineValue,
       isSubmitted: false,
       source: 'user'
     };
 
-  addAssignment(newItem, accessToken); // store의 추가 액션 호출
-  setNewSubject("");
-  setNewTask("");
-  setNewDeadlineDate(getTodayDateString());
-  setNewDeadlineTime("23:59");
-  setShowTimePicker(false);
+    setFormError("");
+    addAssignment(newItem, accessToken); // store의 추가 액션 호출
+    setNewSubject("");
+    setNewTask("");
+    setNewDeadlineDate(getTodayDateString());
+    setNewDeadlineTime("23:59");
+    setShowTimePicker(false);
   };
 
-   // 과제 필터링 함수 : processed + filteredList
-    const processed = useMemo(() => {
+  // 과제 필터링 함수 : processed + filteredList
+  const processed = useMemo(() => {
     const now = new Date();
     return assignment.map(item => {
       
@@ -202,21 +226,20 @@ function AssignmentTab({ accessToken }) {
 
   const filteredList = useMemo(() => {
     return processed.filter(item => {
-
       const isExpired = item.isExpired;
       
       // 태그 선택 안하면 전체 표시
       if (activeTags.length === 0) return true;
 
-          return activeTags.every(tag => {
-            if (tag === STATUS.SUBMITTED) return item.isSubmitted;
-            if (tag === STATUS.UNSUBMITTED) return !item.isSubmitted;
-            if (tag === STATUS.ONGOING) return !isExpired;
-            if (tag === STATUS.OVERDUE) return isExpired;
-            return true;
-          });
-        });
-      }, [processed, activeTags]);
+      return activeTags.every(tag => {
+        if (tag === STATUS.SUBMITTED) return item.isSubmitted;
+        if (tag === STATUS.UNSUBMITTED) return !item.isSubmitted;
+        if (tag === STATUS.ONGOING) return !isExpired;
+        if (tag === STATUS.OVERDUE) return isExpired;
+        return true;
+      });
+    });
+  }, [processed, activeTags]);
 
 
   const sortedList = useMemo(() => { // 남은 기한이 적은 순으로 과제 정렬
@@ -270,11 +293,29 @@ function AssignmentTab({ accessToken }) {
       <form className="add-form" onSubmit={handleAddAssignment}> {/* 과제 생성 영역 */}
         <div className="input-group">
           <div className="input-field">
-            <input type="text" placeholder="과목" value={newSubject} onChange={e => setNewSubject(e.target.value)} />
+            <input
+              type="text"
+              placeholder="과목"
+              value={newSubject}
+              maxLength={SUBJECT_MAX_LENGTH}
+              onChange={e => {
+                setNewSubject(e.target.value);
+                if (formError) setFormError("");
+              }}
+            />          
           </div>
 
           <div className="input-field">
-            <input type="text" placeholder="할 일" value={newTask} onChange={e => setNewTask(e.target.value)} />
+            <input
+              type="text"
+              placeholder="할 일"
+              value={newTask}
+              maxLength={TASK_MAX_LENGTH}
+              onChange={e => {
+                setNewTask(e.target.value);
+                if (formError) setFormError("");
+              }}
+            />          
           </div>
 
           <div className="input-field deadline-field">
@@ -288,7 +329,10 @@ function AssignmentTab({ accessToken }) {
                 aria-label="마감 날짜"
                 onMouseDown={() => setShowTimePicker(false)}
                 onFocus={() => setShowTimePicker(false)}
-                onChange={e => setNewDeadlineDate(e.target.value)}
+                onChange={e => {
+                  setNewDeadlineDate(e.target.value);
+                  if (formError) setFormError("");
+                }}
                 required
               />
 
@@ -368,6 +412,11 @@ function AssignmentTab({ accessToken }) {
           </div>
         </div>
       <button type="submit" className="add-submit-btn">새 과제 추가</button>
+      {formError && (
+        <p className="add-form-error" role="alert">
+          {formError}
+        </p>
+      )}
     </form>
 
         <div className="tag-container"><p>필터</p> {/* 필터링 태그 */}

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -24,6 +24,7 @@ const getMaxDeadlineDateString = () => {
   return `${year}-${month}-${date}`;
 };
 
+// 커스텀 과제 마감일 입력 범위 제한
 const MIN_DEADLINE_DATE = getTodayDateString();
 const MAX_DEADLINE_DATE = getMaxDeadlineDateString();
 
@@ -48,8 +49,8 @@ const CountdownText = ({ deadlineDate }) => {
     return <span className="dday-text">날짜 오류</span>;
   }
 
-const diff = deadlineDate - now;
-if (diff <= 0) return <span className="dday-text">기한 종료</span>; // 기한이 지났을 경우 처리
+  const diff = deadlineDate - now;
+  if (diff <= 0) return <span className="dday-text">기한 종료</span>; // 기한이 지났을 경우 처리
 
   const days = Math.floor(diff / (1000 * 60 * 60 * 24));
   const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -17,6 +17,7 @@ const getTodayDateString = () => {
 // 커스텀 과제 마감일 입력 범위 제한
 const MIN_DEADLINE_DATE = "2000-01-01";
 const MAX_DEADLINE_DATE = "2099-12-31";
+const TIME_ERROR_MESSAGE = "마감 시간은 00:00부터 23:59까지 입력할 수 있습니다.";
 
 // 과목 및 과제 입력 범위 제한
 const SUBJECT_MAX_LENGTH = 30;
@@ -123,28 +124,51 @@ function AssignmentTab({ accessToken }) {
   };
 
   const normalizeTimeInput = (value) => {
-    const [hour = "", minute = ""] = value.split(":");
+    const onlyNumbers = value.replace(/\D/g, "").slice(0, 4);
+
+    let hour = "";
+    let minute = "";
+
+    if (onlyNumbers.length === 0) {
+      return { value: "23:59", isValid: false };
+    }
+
+    if (onlyNumbers.length <= 2) {
+      hour = onlyNumbers.padStart(2, "0");
+      minute = "00";
+    } else if (onlyNumbers.length === 3) {
+      hour = onlyNumbers.slice(0, 2);
+      minute = `${onlyNumbers.slice(2)}0`;
+    } else {
+      hour = onlyNumbers.slice(0, 2);
+      minute = onlyNumbers.slice(2, 4);
+    }
+
     const hourNumber = Number(hour);
     const minuteNumber = Number(minute);
 
     if (
-      hour.length !== 2 ||
-      minute.length !== 2 ||
       Number.isNaN(hourNumber) ||
       Number.isNaN(minuteNumber) ||
-      hourNumber < 0 ||
-      minuteNumber < 0 ||
       hourNumber > 23 ||
       minuteNumber > 59
     ) {
-      return "23:59";
+      return { value: "23:59", isValid: false };
     }
 
-    return `${String(hourNumber).padStart(2, "0")}:${String(minuteNumber).padStart(2, "0")}`;
+    return { value: `${hour}:${minute}`, isValid: true };
   };
 
   const handleTimeBlur = () => {
-    setNewDeadlineTime((prev) => normalizeTimeInput(prev));
+    setNewDeadlineTime((prev) => {
+      const result = normalizeTimeInput(prev);
+
+      if (!result.isValid) {
+        setFormError(TIME_ERROR_MESSAGE);
+      }
+
+      return result.value;
+    });
   };
 
   const handleAddAssignment = (e) => {
@@ -174,7 +198,14 @@ function AssignmentTab({ accessToken }) {
     }
 
     const normalizedDeadlineTime = normalizeTimeInput(newDeadlineTime);
-    const deadlineValue = `${newDeadlineDate}T${normalizedDeadlineTime}:59`;
+
+    if (!normalizedDeadlineTime.isValid) {
+      setFormError(TIME_ERROR_MESSAGE);
+      setNewDeadlineTime(normalizedDeadlineTime.value);
+      return;
+    }
+
+    const deadlineValue = `${newDeadlineDate}T${normalizedDeadlineTime.value}:59`;
     const deadlineDate = new Date(deadlineValue);
     const minDate = new Date(`${MIN_DEADLINE_DATE}T00:00:00`);
     const maxDate = new Date(`${MAX_DEADLINE_DATE}T23:59:59`);
@@ -374,7 +405,8 @@ function AssignmentTab({ accessToken }) {
                             key={value}
                             className={isSelected ? "selected" : ""}
                             onClick={() => {
-                              const minute = newDeadlineTime.slice(3, 5) || "00";
+                              const normalizedTime = normalizeTimeInput(newDeadlineTime);
+                              const minute = normalizedTime.value.slice(3, 5);
                               setNewDeadlineTime(`${value}:${minute}`);
                             }}
                           >
@@ -395,7 +427,8 @@ function AssignmentTab({ accessToken }) {
                             key={value}
                             className={isSelected ? "selected" : ""}
                             onClick={() => {
-                              const hour = newDeadlineTime.slice(0, 2) || "23";
+                              const normalizedTime = normalizeTimeInput(newDeadlineTime);
+                              const hour = normalizedTime.value.slice(0, 2);
                               setNewDeadlineTime(`${hour}:${value}`);
                               setShowTimePicker(false);
                             }}

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -172,7 +172,7 @@ function AssignmentTab({ accessToken }) {
 
 
   return (
-    <div className="assignment-wrapper">
+    <>
 
       <form className="add-form" onSubmit={handleAddAssignment}> {/* 과제 생성 영역 */}
         <div className="input-group">
@@ -192,7 +192,7 @@ function AssignmentTab({ accessToken }) {
           <button type="submit" className="add-submit-btn">새 과제 추가</button>
       </form>
 
-        <div className="tag-container"><p>상세 필터:</p> {/* 필터링 태그 */}
+        <div className="tag-container"><p>필터</p> {/* 필터링 태그 */}
           {[
             { id: STATUS.UNSUBMITTED, label: '미제출' },
             { id: STATUS.SUBMITTED,   label: '제출' },
@@ -279,7 +279,7 @@ function AssignmentTab({ accessToken }) {
           document.body
         )}
       </div>
-    </div>
+    </>
   );
 }
 export default AssignmentTab;

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -13,6 +13,9 @@ const getTodayDateString = () => {
   return `${year}-${month}-${date}`;
 };
 
+const MIN_DEADLINE_DATE = getTodayDateString();
+const MAX_DEADLINE_DATE = "2099-12-31";
+
 const STATUS = {
   UNSUBMITTED: 'UNSUBMITTED',
   SUBMITTED: 'SUBMITTED',
@@ -30,8 +33,12 @@ const CountdownText = ({ deadlineDate }) => {
     return () => clearInterval(timer); // 언마운트 시 클린업
   }, []);
 
-  const diff = deadlineDate - now;
-  if (diff <= 0) return <span className="dday-text">기한 종료</span>; // 기한이 지났을 경우 처리
+  if (!deadlineDate || Number.isNaN(deadlineDate.getTime())) {
+    return <span className="dday-text">날짜 오류</span>;
+  }
+
+const diff = deadlineDate - now;
+if (diff <= 0) return <span className="dday-text">기한 종료</span>; // 기한이 지났을 경우 처리
 
   const days = Math.floor(diff / (1000 * 60 * 60 * 24));
   const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
@@ -68,7 +75,7 @@ function AssignmentTab({ accessToken }) {
   
   const [newSubject, setNewSubject] = useState("");
   const [newTask, setNewTask] = useState("");
-  const [newDeadlineDate, setNewDeadlineDate] = useState(getTodayDateString());
+  const [newDeadlineDate, setNewDeadlineDate] = useState(getTodayDateString);
   const [newDeadlineTime, setNewDeadlineTime] = useState("23:59");
   const [showTimePicker, setShowTimePicker] = useState(false);
 
@@ -96,11 +103,11 @@ function AssignmentTab({ accessToken }) {
 
   // 과제 추가 로직
   const formatTimeInput = (value) => {
-  const onlyNumbers = value.replace(/\D/g, "").slice(0, 4);
+    const onlyNumbers = value.replace(/\D/g, "").slice(0, 4);
 
-  if (onlyNumbers.length <= 2) return onlyNumbers;
+    if (onlyNumbers.length <= 2) return onlyNumbers;
 
-  return `${onlyNumbers.slice(0, 2)}:${onlyNumbers.slice(2)}`;
+    return `${onlyNumbers.slice(0, 2)}:${onlyNumbers.slice(2)}`;
   };
 
   const handleTimeChange = (e) => {
@@ -132,30 +139,52 @@ function AssignmentTab({ accessToken }) {
   const handleAddAssignment = (e) => {
     e.preventDefault();
 
-    const newItem = {
-    id: Date.now(),
-    subject: newSubject,
-    task: newTask,
-    deadline: `${newDeadlineDate}T${newDeadlineTime}:59`,
-    isSubmitted: false,
-    source: 'user'
-  };
+    const deadlineValue = `${newDeadlineDate}T${newDeadlineTime}:59`;
+    const deadlineDate = new Date(deadlineValue);
+    const minDate = new Date(`${MIN_DEADLINE_DATE}T00:00:00`);
+    const maxDate = new Date(`${MAX_DEADLINE_DATE}T23:59:59`);
 
-  addAssignment(newItem);
-  setNewSubject("");
-  setNewTask("");
-  setNewDeadlineDate(getTodayDateString());
-  setNewDeadlineTime("23:59");
-  setShowTimePicker(false);
+    if (Number.isNaN(deadlineDate.getTime())) {
+      alert("올바른 마감 날짜를 입력해주세요.");
+      return;
+    }
+
+    if (deadlineDate < minDate || deadlineDate > maxDate) {
+      alert("마감 날짜는 오늘부터 2099년 12월 31일까지만 입력할 수 있습니다.");
+      return;
+    }
+
+    const newItem = {
+      id: Date.now(),
+      subject: newSubject,
+      task: newTask,
+      deadline: deadlineValue,
+      isSubmitted: false,
+      source: 'user'
+    };
+
+    addAssignment(newItem);
+    setNewSubject("");
+    setNewTask("");
+    setNewDeadlineDate(getTodayDateString());
+    setNewDeadlineTime("23:59");
+    setShowTimePicker(false);
   };
 
    // 과제 필터링 함수 : processed + filteredList
-  const processed = useMemo(() => {
+    const processed = useMemo(() => {
     const now = new Date();
     return assignment.map(item => {
       
       const deadlineDate = new Date(item.deadline);
-      return { ...item, deadlineDate, isExpired: deadlineDate - now <= 0 };
+      const isValidDeadline = !Number.isNaN(deadlineDate.getTime());
+
+      return {
+        ...item,
+        deadlineDate,
+        isValidDeadline,
+        isExpired: isValidDeadline ? deadlineDate - now <= 0 : false
+      };
     });
   }, [assignment]);
 
@@ -180,7 +209,12 @@ function AssignmentTab({ accessToken }) {
 
 
   const sortedList = useMemo(() => { // 남은 기한이 적은 순으로 과제 정렬
-    return [...filteredList].sort((a, b) => a.deadlineDate - b.deadlineDate);
+    return [...filteredList].sort((a, b) => {
+      if (!a.isValidDeadline && !b.isValidDeadline) return 0;
+      if (!a.isValidDeadline) return 1;
+      if (!b.isValidDeadline) return -1;
+      return a.deadlineDate - b.deadlineDate;
+    });
   }, [filteredList]);
   
   const confirmDelete = () => {
@@ -238,6 +272,10 @@ function AssignmentTab({ accessToken }) {
               <input
                 type="date"
                 value={newDeadlineDate}
+                min={MIN_DEADLINE_DATE}
+                max={MAX_DEADLINE_DATE}
+                title="마감 날짜를 선택하거나 YYYY-MM-DD 형식으로 입력하세요."
+                aria-label="마감 날짜"
                 onMouseDown={() => setShowTimePicker(false)}
                 onFocus={() => setShowTimePicker(false)}
                 onChange={e => setNewDeadlineDate(e.target.value)}
@@ -366,8 +404,10 @@ function AssignmentTab({ accessToken }) {
                   {item.isSubmitted ? '제출 완료' : '미제출'}
                 </div>
 
-                <span className="deadline-text"> 기한: {item.deadline.replace('T', ' ').slice(0, 16)}</span>
-                <CountdownText deadlineDate={item.deadlineDate} /> 
+                <span className="deadline-text">
+                  기한: {item.isValidDeadline ? item.deadline.replace('T', ' ').slice(0, 16) : '날짜 오류'}
+                </span>
+                <CountdownText deadlineDate={item.deadlineDate} />
 
                 <div className="item-actions"> {/* 생성과제 - 삭제, 완료 처리 버튼 영역 */}
                     {item.source === 'user' ? (

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -4,6 +4,15 @@ import './AssignmentTab.css';
 import useAssignmentStore from '../../store/useAssignmentStore';
 import AssignmentDetail from './AssignmentDetail';
 
+const getTodayDateString = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const date = String(today.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${date}`;
+};
+
 const STATUS = {
   UNSUBMITTED: 'UNSUBMITTED',
   SUBMITTED: 'SUBMITTED',
@@ -59,7 +68,7 @@ function AssignmentTab({ accessToken }) {
   
   const [newSubject, setNewSubject] = useState("");
   const [newTask, setNewTask] = useState("");
-  const [newDeadlineDate, setNewDeadlineDate] = useState("");
+  const [newDeadlineDate, setNewDeadlineDate] = useState(getTodayDateString());
   const [newDeadlineTime, setNewDeadlineTime] = useState("23:59");
   const [showTimePicker, setShowTimePicker] = useState(false);
 
@@ -135,7 +144,7 @@ function AssignmentTab({ accessToken }) {
   addAssignment(newItem);
   setNewSubject("");
   setNewTask("");
-  setNewDeadlineDate("");
+  setNewDeadlineDate(getTodayDateString());
   setNewDeadlineTime("23:59");
   setShowTimePicker(false);
   };

--- a/client/src/Components/main_page/MainPage.jsx
+++ b/client/src/Components/main_page/MainPage.jsx
@@ -43,7 +43,7 @@ function MainPage({ accessToken, onLogout }) {
               <div className="top-right-menu">
                   {/* 테마 토글 버튼: 현재 상태에 따라 해/달 아이콘 표시 */}
                   <button onClick={toggleTheme} className="dark-button">
-                      {theme === 'dark' ? '🌞' : '🌙'}
+                      {theme === 'dark' ? '🌙' : '🌞'}
                   </button>
 
                   {/* 마이페이지 이동 버튼 */}

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -74,11 +74,11 @@ class CustomAPIResponse(BaseModel): # 커스텀 API 응답 스키마
 
 class CustomAssignmentRequest(BaseModel):
     id: Optional[str] = None
-    subject: str = Field(..., max_length=100)
-    task: str = Field(..., max_length=200)
+    subject: str = Field(..., min_length=1, max_length=30)
+    task: str = Field(..., min_length=1, max_length=50)
     deadline: str = Field(..., max_length=50)
     isSubmitted: bool = False
-    description: Optional[str] = Field(None, max_length=2000)
+    description: Optional[str] = Field(None, max_length=1000)
 
 security = HTTPBearer() # 인증 객체
 


### PR DESCRIPTION
## 관련 이슈
#57 

## 작업 내용

- 커스텀 과제 추가 영역의 흰색 테두리 박스를 제거하고 입력 요소 높이를 통일했습니다.
- 필터 문구를 `상세 필터`에서 `필터`로 변경하고 필터 영역 배경색을 제거했습니다.
- 커스텀 과제 마감 시간 입력을 24시간제 방식으로 변경해 `오전/오후` 표시를 제거했습니다.
- 커스텀 과제 기본 마감값을 현재 날짜 `23:59`로 설정했습니다.
- 마감 날짜 입력 범위를 오늘부터 5년 이내로 제한하고, 비정상 날짜로 인해 남은 시간이 `NaN`으로 표시되지 않도록 방어 로직을 추가했습니다.
- 다크모드/라이트모드 상태에 맞게 테마 토글 아이콘 표시를 수정했습니다.
- 과제탭의 불필요한 최상위 wrapper를 제거해 마이페이지 레이아웃과 통일했습니다.

## 확인 사항

- [x] 커스텀 과제 추가 영역 UI 확인
- [x] 24시간제 시간 직접 입력 및 선택 확인
- [x] 기본 마감값이 현재 날짜 `23:59`로 설정되는지 확인
- [x] 오늘 이전 날짜 및 5년 초과 날짜 입력 제한 확인
- [x] 과제 목록 남은 시간에 `NaN`이 표시되지 않는지 확인
- [x] 다크모드/라이트모드 아이콘 표시 확인

<img width="1902" height="918" alt="image" src="https://github.com/user-attachments/assets/ec562b07-0c55-4025-a194-178adfee59fd" />
