### PR TITLE
Feature_notice-tab : 과목 공지사항 상세보기 기능 구현 

### DIFF
--- a/client/src/Components/assignment-tab/AssignmentDetail.css
+++ b/client/src/Components/assignment-tab/AssignmentDetail.css
@@ -13,7 +13,7 @@
 
 .detail-modal {
   place-self: center;
-  width: 600px;
+  width: 700px;
   max-height: 80vh;
   overflow-y: auto;
   background: var(--bg-card);
@@ -23,6 +23,10 @@
   position: relative;
   box-shadow: var(--card-shadow-hover);
   color: var(--text-main);
+
+  overflow: hidden;           
+  display: flex;
+  flex-direction: column;
 }
 
 .detail-text {
@@ -31,6 +35,14 @@
   font-size: 15px;
   font-family: inherit;
   color: var(--text-main);
+  overflow-y: auto;
+}
+
+/* 전체 모달 내용 스크롤 영역 */
+.detail-modal-body {
+  overflow-y: auto;
+  flex: 1;
+  padding: 0 4px;
 }
 
 .close-btn {
@@ -60,7 +72,8 @@
 .detail-info {
   margin-bottom: 15px;
   font-size: 0.9em;
-  color: var(--text-muted);
+  color: var(--text-color);
+  overflow-y: auto;
 }
 
 .detail-footer {
@@ -77,7 +90,7 @@
 
 .detail-section-title {
   font-size: 0.9em;
-  font-weight: bold;
+  font-weight: 500;
   color: var(--text-muted);
 }
 

--- a/client/src/Components/assignment-tab/AssignmentTab.css
+++ b/client/src/Components/assignment-tab/AssignmentTab.css
@@ -470,6 +470,15 @@ body.modal-open .left:hover {
   color: var(--btn-text);
 }
 
+/* JSX 코드 내의 인라인 스타일 대체하는 빈 화면 전용 클래스 추가 */
+.notice-empty {
+  text-align: center;
+  padding: 20px 0;
+  color: var(--text-main);
+  opacity: 0.5;
+  font-size: 0.9rem;
+}
+
 @media screen and (max-width: 768px) {
   .info {
     width: 100%;

--- a/client/src/Components/assignment-tab/AssignmentTab.jsx
+++ b/client/src/Components/assignment-tab/AssignmentTab.jsx
@@ -473,10 +473,10 @@ function AssignmentTab({ accessToken }) {
       <header> <p className="tab-title">과제 목록({filteredList.length})</p></header>
       {/* 로딩 중일 때와 아닐 때를 구분해서 렌더링 */}
       {isLoading && assignment.length === 0 ? (
-        <div style={{ textAlign: 'center', padding: '40px' }}>데이터를 불러오는 중입니다...</div>
+        <p className="notice-empty">데이터를 불러오는 중입니다...</p>
       ) : (
       <ul className="mainbox"> {/* 과제 없는 경우 */}
-        {sortedList.length === 0 ? <p>과제가 없습니다.</p> :
+        {sortedList.length === 0 ? <p className="notice-empty">과제가 없습니다.</p> :
             sortedList.map(item => (
              <li
                 className={`assignment-item ${getItemClass(item.isExpired, item.isSubmitted)}`}

--- a/client/src/Components/main_page/MainPage.jsx
+++ b/client/src/Components/main_page/MainPage.jsx
@@ -40,7 +40,7 @@ function MainPage({ accessToken, onLogout }) {
 
           <div className="left-section">
             <div className="left"><AssignmentTab accessToken={accessToken}/></div>
-            <div className="left"><NoticeTab/></div>
+            <div className="left"><NoticeTab accessToken={accessToken}/></div>
           </div>
 
           <div className="right">Ai 기능</div>

--- a/client/src/Components/notice-tab/NoticeTab.css
+++ b/client/src/Components/notice-tab/NoticeTab.css
@@ -141,6 +141,48 @@
   font-size: 0.9rem;
 }
 
+/* HTML 본문 렌더링 영역 */
+.detail-html-content {
+  font-size: 0.9rem;
+  line-height: 1.7;
+  color: var(--text-main);
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+/* 이미지 넘침 방지 */
+.detail-html-content img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 8px 0;
+}
+
+/* 표 스타일 */
+.detail-html-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 0.85rem;
+}
+
+.detail-html-content th,
+.detail-html-content td {
+  border: 1px solid var(--border);
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.detail-html-content th {
+  background-color: var(--bg-card);
+  font-weight: 600;
+}
+
+/* 단락 간격 */
+.detail-html-content p {
+  margin: 0 0 10px 0;
+}
+
 @media screen and (max-width: 1300px) {
   .notice-section {
     padding: 22px; 

--- a/client/src/Components/notice-tab/NoticeTab.css
+++ b/client/src/Components/notice-tab/NoticeTab.css
@@ -8,10 +8,18 @@
   border-bottom: 1px solid var(--border);
 }
 
+.notice-header-right {
+  display: flex;
+  flex-direction: column; 
+  align-items: flex-end;  
+  gap: 10px;          
+}
+
 .notice-title-group {
   display: flex;
   align-items: center;
   gap: 10px;
+  justify-content: space-between;
 }
 
 .notice-title-group h2 {
@@ -25,7 +33,7 @@
   font-size: 1.4rem;
 }
 
-.notice-more-btn {
+.notice-more-btn { 
   padding: 6px 10px;
   border: 1px solid var(--accent);
   font-size: 12px;
@@ -34,6 +42,41 @@
   color: #ffffff;
   border-radius: 8px;
   text-decoration: none;
+}
+
+/* 공지사항, 쪽지함 영역 */
+.notice-tab-toggles {
+  display: flex;
+  align-items: center;
+  background-color: var(--bg-card); 
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+}
+
+/* 공지사항, 쪽지함 버튼 */
+.tab-toggle-btn {  
+  padding: 6px 16px;
+  border: none;
+  background: transparent;
+  color: var(--text-main);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.tab-toggle-btn:hover:not(.active) {
+  background-color: var(--shadow-hover);
+}
+
+.tab-toggle-btn.active {
+  background-color: var(--accent);
+  color: #ffffff;
+  font-weight: 600;
+  box-shadow: 0 2px 4px var(--btn-bg-hover); 
 }
 
 .filter-tag-btn:hover {
@@ -87,6 +130,10 @@
   border-bottom: 1px solid var(--border);
   padding: 18px 24px;
   cursor: pointer;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .notice-item:first-child {

--- a/client/src/Components/notice-tab/NoticeTab.css
+++ b/client/src/Components/notice-tab/NoticeTab.css
@@ -3,8 +3,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
-  padding-bottom: 12px;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -17,7 +17,7 @@
 .notice-title-group h2 {
   color: var(--text-header);
   font-weight: 700;
-  font-size: 1.35rem;
+  font-size: 1.5rem;
   margin: 0;
 }
 
@@ -85,17 +85,19 @@
 /* 공지 아이템 */
 .notice-item {
   border-bottom: 1px solid var(--border);
-  padding: 12px 0;
+  padding: 18px 24px;
   cursor: pointer;
 }
 
 .notice-item:first-child {
   padding-top: 4px;
+  padding: 18px 24px;
 }
 
 .notice-item:last-child {
   border-bottom: none;
   padding-bottom: 0;
+  padding: 18px 24px;
 }
 
 .notice-title-area {
@@ -128,6 +130,15 @@
   min-width: 0;
 }
 
+/* 공지 날짜 태그 */
+.notice-item-date {
+  font-size: 0.8rem;
+  color: var(--text-color);
+  flex-shrink: 0;
+  margin-left: 8px;
+  white-space: nowrap;
+}
+
 .notice-item:hover .notice-item-title {
   text-decoration: underline;
 }
@@ -143,7 +154,7 @@
 
 /* HTML 본문 렌더링 영역 */
 .detail-html-content {
-  font-size: 0.9rem;
+  font-size: 15px;
   line-height: 1.7;
   color: var(--text-main);
   word-break: break-word;
@@ -175,12 +186,12 @@
 
 .detail-html-content th {
   background-color: var(--bg-card);
-  font-weight: 600;
+  font-weight: 550;
 }
 
 /* 단락 간격 */
 .detail-html-content p {
-  margin: 0 0 10px 0;
+  margin: 0 0 8px 0;
 }
 
 @media screen and (max-width: 1300px) {

--- a/client/src/Components/notice-tab/NoticeTab.css
+++ b/client/src/Components/notice-tab/NoticeTab.css
@@ -8,13 +8,6 @@
   border-bottom: 1px solid var(--border);
 }
 
-.notice-header-right {
-  display: flex;
-  flex-direction: column; 
-  align-items: flex-end;  
-  gap: 10px;          
-}
-
 .notice-title-group {
   display: flex;
   align-items: center;
@@ -31,17 +24,6 @@
 
 .notice-emoji {
   font-size: 1.4rem;
-}
-
-.notice-more-btn { 
-  padding: 6px 10px;
-  border: 1px solid var(--accent);
-  font-size: 12px;
-  font-weight: 500;
-  background-color: var(--accent);
-  color: #ffffff;
-  border-radius: 8px;
-  text-decoration: none;
 }
 
 /* 공지사항, 쪽지함 영역 */
@@ -158,7 +140,6 @@
 .notice-course-tag {
   font-size: 0.95rem;
   font-weight: 700;
-  color: var(--text-header); 
   margin-right: 8px; 
   flex-shrink: 0; 
 }
@@ -242,26 +223,47 @@
 }
 
 @media screen and (max-width: 1300px) {
-  .notice-section {
-    padding: 22px; 
+  .notice-header {
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+  }
+
+  .notice-title-group h2 {
+    font-size: 1.3rem;
+  }
+
+  .notice-item {
+    padding: 14px 16px;
+  }
+  .notice-item:first-child {
+    padding: 14px 16px;
+  }
+  .notice-item:last-child {
+    padding: 14px 16px;
+  }
+
+  .notice-course-tag, 
+  .notice-item-title {
+    font-size: 0.9rem;
   }
 }
 
 @media screen and (max-width: 768px) {
-  .notice-section {
-    padding: 20px;
-    border-radius: 16px; 
-  }
-
   .notice-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
     margin-bottom: 12px;
     padding-bottom: 10px;
+  }
+  
+  .notice-tab-toggles {
+    align-self: flex-end;
   }
 
   /* 제목, 에모지, 버튼 크기 일괄 축소 */
   .notice-title-group h2 { font-size: 1.15rem; }
   .notice-emoji { font-size: 1.2rem; }
-  .notice-more-btn { padding: 4px 8px; font-size: 11px; }
 
   /* 필터 버튼 영역 축소 */
   .notice-filter-tags { gap: 6px; margin-bottom: 14px; }
@@ -270,4 +272,12 @@
   /* 리스트 텍스트 크기 및 간격 일괄 조정 */
   .notice-item { padding: 10px 0; }
   .notice-course-tag, .notice-item-title { font-size: 0.85rem; }
+
+  .notice-item:first-child {
+    padding: 10px 0 10px 0; 
+  }
+  
+  .notice-item:last-child {
+    padding: 10px 0 0 0;   
+  }
 }

--- a/client/src/Components/notice-tab/NoticeTab.jsx
+++ b/client/src/Components/notice-tab/NoticeTab.jsx
@@ -7,45 +7,45 @@ import { API_BASE_URL } from '../../apiConfig';
 
 
 // Zustand 스토어
-const useNoticeStore = create((set, get) => ({
-  notices: [],
-  isLoading: false,
-  isFetched: false,
+const useLMSStore = create((set, get) => ({
+  notices: { data: [], isLoading: false, isFetched: false },
+  messages: { data: [], isLoading: false, isFetched: false },
 
-  fetchNotices: async (accessToken) => {
-    if (get().isFetched || !accessToken) return;  // 중복 호출 방지
 
-    set({ isLoading: true });
+  fetchData: async (type, accessToken) => { // type: 'notices' | 'messages'
+
+    const state = get()[type];
+    if (state.isFetched || !accessToken) return;  // 중복 호출 방지
+
+    set((prev) => ({ ...prev, [type]: { ...prev[type], isLoading: true } }));
+
     try {
-      const response = await fetch(`${API_BASE_URL}/api/notices`, {
+      const response = await fetch(`${API_BASE_URL}/api/${type}`, {
         headers: { 'Authorization': `Bearer ${accessToken}` },
         credentials: 'include'
       });
 
-      if (!response.ok) {
-        throw new Error(`서버 응답 오류 (Status: ${response.status})`);
-      }
+      if (!response.ok) throw new Error(`Status: ${response.status}`);
 
       const result = await response.json();
       if (result.success) {
-        set({ notices: result.data, isFetched: true });
+        set((prev) => ({ ...prev, [type]: { data: result.data, isLoading: false, isFetched: true } }));
       }
     } catch (error) {
-      console.error("공지사항 로드 실패:", error);
-    } finally {
-      set({ isLoading: false });
+      console.error(`${type} 로드 실패:`, error);
+      set((prev) => ({ ...prev, [type]: { ...prev[type], isLoading: false } }));
     }
   }
 }));
 
 
 function NoticeTab({ accessToken }) {
+  const [activeTab, setActiveTab] = useState('notices');
+  const { notices, messages, fetchData } = useLMSStore();
 
-  const { notices, isLoading, fetchNotices } = useNoticeStore();
-
-  useEffect(() => {
-    fetchNotices(accessToken);
-  }, [fetchNotices, accessToken]);
+   useEffect(() => {
+    fetchData(activeTab, accessToken);
+  }, [activeTab, fetchData, accessToken]);
 
   const [selectedCourse, setSelectedCourse] = useState('all'); // 선택 과목 ID 상태
   const [selectedNotice, setSelectedNotice] = useState(null); // 상세보기 모달 상태 (객체 저장)
@@ -61,21 +61,29 @@ function NoticeTab({ accessToken }) {
   // 과목 태그 목록 생성 (중복 제거)
   const courses = useMemo(() => [
     { id: 'all', name: '전체' },
-    ...Array.from(
-      new Map(notices.map(n => [n.course_id, n.course_name])).entries()
-    ).map(([id, name]) => ({ id, name }))
-  ], [notices]);
+    ...Array.from(new Map(notices.data.map(n => [n.course_id, n.course_name])).entries())
+      .map(([id, name]) => ({ id, name }))
+  ], [notices.data]);
 
 
   // 선택한 과목 필터링 리스트
-  const filtered = useMemo(() =>
+  const filteredNotices = useMemo(() =>
     selectedCourse === 'all'
-      ? notices
-      : notices.filter(n => n.course_id === selectedCourse),
-  [notices, selectedCourse]);
+      ? notices.data
+      : notices.data.filter(n => n.course_id === selectedCourse),
+  [notices.data, selectedCourse]);
+
+  // 리스트 렌더링용 변수 통합 
+  const isNotice = activeTab === 'notices';
+  const currentData = isNotice ? notices : messages;
+  const listItems = isNotice ? filteredNotices : messages.data;
+  const emptyText = isNotice ? '공지사항이 없습니다.' : '받은 쪽지가 없습니다.';
+
 
   // 공지 클릭 시 상세 모달 — description_html 없으면 상세 API 호출
   const handleNoticeClick = async (item) => {
+    if (!isNotice) return;
+
     // description_html이 없으면 항상 상세 API 호출
     if (item.description_html) {
       setSelectedNotice(item);
@@ -98,20 +106,49 @@ function NoticeTab({ accessToken }) {
     }
   };
 
+  // 문자를 입력받아 css 변수명 변경(과목 색 변)
+  const getColorForString = (str) => {
+  if (!str) return 'var(--text-main)';
+
+  const colorVars = [
+    'var(--tag-color-0)', 'var(--tag-color-1)', 'var(--tag-color-2)', 
+    'var(--tag-color-3)', 'var(--tag-color-4)', 'var(--tag-color-5)', 
+    'var(--tag-color-6)', 'var(--tag-color-7)', 'var(--tag-color-8)', 
+    'var(--tag-color-9)'
+  ];
+  
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  
+  const index = Math.abs(hash) % colorVars.length;
+  return colorVars[index];
+};
+
+
   return (
     <div>
       <div className="notice-header">
         <div className="notice-title-group">
-          <span className="notice-emoji">📖</span>
-          <h2>과목별 공지 및 과제</h2>
+          <span className="notice-emoji">{isNotice ? '📖' : '✉️'}</span>
+          <h2>{isNotice ? '과목별 공지 및 과제' : '받은 쪽지함'}</h2>
         </div>
-        <a href="https://lms.chungbuk.ac.kr" target="_blank" rel="noreferrer" className="notice-more-btn">
-          LMS 바로가기
-        </a>
+
+        <div className="notice-header-right">
+          <div className="notice-tab-toggles">
+            <button className={`tab-toggle-btn ${isNotice ? 'active' : ''}`} onClick={() => setActiveTab('notices')}>공지사항</button>
+            <button className={`tab-toggle-btn ${!isNotice ? 'active' : ''}`} onClick={() => setActiveTab('messages')}>쪽지함</button>
+          </div>
+
+          <a href="https://lms.chungbuk.ac.kr" target="_blank" rel="noreferrer" className="notice-more-btn">
+            LMS 바로가기
+          </a>
+        </div>
       </div>
 
       {/* 상단 과목 필터 버튼들 */}
-      <div className="notice-filter-tags">
+      {isNotice && ( <div className="notice-filter-tags">
         {courses.map(c => (
           <button
             key={c.id}
@@ -122,37 +159,64 @@ function NoticeTab({ accessToken }) {
           </button>
         ))}
       </div>
+      )}
 
       {/* 공지 리스트 렌더링 */}
-      {isLoading ? (
-        <div className="notice-empty">공지사항을 불러오는 중입니다...</div>
+      {currentData.isLoading ? (<div className="notice-empty">데이터를 불러오는 중입니다...</div>
       ) : (
 
       <ul className="notice-list">
-        {filtered.length === 0 ? (
-          <p className="notice-empty">공지사항이 없습니다.</p>
+        {listItems.length === 0 ? (
+          <p className="notice-empty">{emptyText}</p>
         ) : (
-          filtered.map((item, index) => (
-            // id가 없으므로 course_id와 index 조합으로 key 생성
+           listItems.map((item, index) => { // 탭에 따라 매핑할 데이터 다르게 설정
+              const key = isNotice ? `${item.course_id}-${index}` : item.message_id;
+              const tag = isNotice ? item.course_name : item.sender;
+              const title = isNotice ? item.title : item.content;
+              const date = isNotice ? item.date?.slice(0, 10) : item.date;
+
+              const tagColor = getColorForString(tag);
+
+              return (
             <li 
-              key={`${item.course_id}-${index}`} 
+              key={key} 
               className="notice-item" 
               onClick={() => handleNoticeClick(item)} 
-              style={{ cursor: 'pointer' }}
+              style={{ cursor: isNotice ? 'pointer' : 'default' }}
             >
               <div className="notice-title-area">
-                <span className="notice-course-tag">[{item.course_name}]</span>
-                <span className="notice-item-title">{item.title}</span>
-                {item.date && (
-                  <span className="notice-item-date">
-                    {item.date.slice(0, 10)}  {/* 날짜 부분만 표시 */}
+                <span 
+                    className="notice-course-tag" 
+                    style={{ color: tagColor }} 
+                  >
+                    [{tag}]
                   </span>
-                 )}
+
+                {/* 쪽지이면서 url이 존재할 경우에만 링크 적용 */}
+                {!isNotice && item.url ? (
+                  <a href={item.url} 
+                  target="_blank" 
+                  rel="noreferrer" 
+                  className="notice-item-title" 
+                  style={{ textDecoration: 'none', color: 'inherit' }}>
+                      {title}
+                    </a>
+                  ) : (
+
+                <span className="notice-item-title">{title}</span>
+                )}
               </div>
-            </li>
-          ))
-        )}
-      </ul>
+
+                {date && (
+                  <span className="notice-item-date">
+                    {date.slice(0, 10)}  {/* 날짜 부분만 표시 */}
+                  </span>
+                  )}
+                </li>
+              );
+            })
+          )}
+        </ul>
       )}
 
       {/* Portal을 통한 상세 보기 모달 팝업 */}

--- a/client/src/Components/notice-tab/NoticeTab.jsx
+++ b/client/src/Components/notice-tab/NoticeTab.jsx
@@ -25,7 +25,7 @@ const useNoticeStore = create((set, get) => ({
       if (!response.ok) {
         throw new Error(`서버 응답 오류 (Status: ${response.status})`);
       }
-      
+
       const result = await response.json();
       if (result.success) {
         set({ notices: result.data, isFetched: true });
@@ -39,9 +39,14 @@ const useNoticeStore = create((set, get) => ({
 }));
 
 
-function NoticeTab() {
+function NoticeTab({ accessToken }) {
 
-  const { notices } = useNoticeStore(); // 스토어 데이터 구독
+  const { notices, isLoading, fetchNotices } = useNoticeStore();
+
+  useEffect(() => {
+    fetchNotices(accessToken);
+  }, [fetchNotices, accessToken]);
+
   const [selectedCourse, setSelectedCourse] = useState('all'); // 선택 과목 ID 상태
   const [selectedNotice, setSelectedNotice] = useState(null); // 상세보기 모달 상태 (객체 저장)
 
@@ -69,6 +74,29 @@ function NoticeTab() {
       : notices.filter(n => n.course_id === selectedCourse),
   [notices, selectedCourse]);
 
+  // 공지 클릭 시 상세 모달 — description 없으면 API 호출
+  const handleNoticeClick = async (item) => {
+    if (item.description) {
+      setSelectedNotice(item);
+    } else {
+      try {
+        const response = await fetch(
+          `${API_BASE_URL}/api/notices/${item.board_id}/${item.notice_id}`,
+          {
+            headers: { 'Authorization': `Bearer ${accessToken}` },
+            credentials: 'include'
+          }
+        );
+        const result = await response.json();
+        if (result.success) {
+          setSelectedNotice({ ...item, ...result.data });
+        }
+      } catch (error) {
+        console.error("공지 상세 조회 실패:", error);
+      }
+    }
+  };
+
   return (
     <div>
       <div className="notice-header">
@@ -95,26 +123,31 @@ function NoticeTab() {
       </div>
 
       {/* 공지 리스트 렌더링 */}
+      {isLoading ? (
+        <p className="notice-empty">공지사항을 불러오는 중입니다...</p>
+      ) : (
+
       <ul className="notice-list">
         {filtered.length === 0 ? (
-          <p style={{ textAlign: 'center', padding: '20px', color: '#888' }}>공지사항이 없습니다.</p>
+          <p className="notice-empty">공지사항이 없습니다.</p>
         ) : (
           filtered.map((item, index) => (
             // id가 없으므로 course_id와 index 조합으로 key 생성
             <li 
               key={`${item.course_id}-${index}`} 
               className="notice-item" 
-              onClick={() => setSelectedNotice(item)} 
+              onClick={() => handleNoticeClick(item)} 
               style={{ cursor: 'pointer' }}
             >
               <div className="notice-title-area">
                 <span className="notice-course-tag">[{item.course_name}]</span>
-                <span className="notice-item-title">{item.assignment_name}</span>
+                <span className="notice-item-title">{item.title}</span>
               </div>
             </li>
           ))
         )}
       </ul>
+      )}
 
       {/* Portal을 통한 상세 보기 모달 팝업 */}
       {selectedNotice && createPortal(
@@ -122,9 +155,11 @@ function NoticeTab() {
           <div className="detail-modal" onClick={e => e.stopPropagation()}>
             <button className="close-btn" onClick={() => setSelectedNotice(null)}>✕</button>
             <h3>공지 상세 정보</h3>
-            <div style={{ marginBottom: '15px', fontSize: '0.9em', color: '#a3a3a3' }}>
+            <div className="detail-info">
               <p><strong>과목:</strong> {selectedNotice.course_name}</p>
-              <p><strong>제목:</strong> {selectedNotice.assignment_name}</p>
+              <p><strong>제목:</strong> {selectedNotice.title}</p>
+              {selectedNotice.writer && <p><strong>작성자:</strong> {selectedNotice.writer}</p>}
+              {selectedNotice.date && <p><strong>작성일:</strong> {selectedNotice.date}</p>}
             </div>
             <hr />
             <span className="detail-section-title">공지 내용</span>

--- a/client/src/Components/notice-tab/NoticeTab.jsx
+++ b/client/src/Components/notice-tab/NoticeTab.jsx
@@ -106,7 +106,7 @@ function NoticeTab({ accessToken }) {
     }
   };
 
-  // 문자를 입력받아 css 변수명 변경(과목 색 변)
+  // 문자를 입력받아 css 변수명 변경(과목 색 변경)
   const getColorForString = (str) => {
   if (!str) return 'var(--text-main)';
 
@@ -132,20 +132,14 @@ function NoticeTab({ accessToken }) {
       <div className="notice-header">
         <div className="notice-title-group">
           <span className="notice-emoji">{isNotice ? '📖' : '✉️'}</span>
-          <h2>{isNotice ? '과목별 공지 및 과제' : '받은 쪽지함'}</h2>
+          <h2>{isNotice ? '과목별 공지' : '받은 쪽지함'}</h2>
         </div>
 
-        <div className="notice-header-right">
           <div className="notice-tab-toggles">
             <button className={`tab-toggle-btn ${isNotice ? 'active' : ''}`} onClick={() => setActiveTab('notices')}>공지사항</button>
             <button className={`tab-toggle-btn ${!isNotice ? 'active' : ''}`} onClick={() => setActiveTab('messages')}>쪽지함</button>
           </div>
-
-          <a href="https://lms.chungbuk.ac.kr" target="_blank" rel="noreferrer" className="notice-more-btn">
-            LMS 바로가기
-          </a>
         </div>
-      </div>
 
       {/* 상단 과목 필터 버튼들 */}
       {isNotice && ( <div className="notice-filter-tags">

--- a/client/src/Components/notice-tab/NoticeTab.jsx
+++ b/client/src/Components/notice-tab/NoticeTab.jsx
@@ -74,9 +74,10 @@ function NoticeTab({ accessToken }) {
       : notices.filter(n => n.course_id === selectedCourse),
   [notices, selectedCourse]);
 
-  // 공지 클릭 시 상세 모달 — description 없으면 API 호출
+  // 공지 클릭 시 상세 모달 — description_html 없으면 상세 API 호출
   const handleNoticeClick = async (item) => {
-    if (item.description) {
+    // description_html이 없으면 항상 상세 API 호출
+    if (item.description_html) {
       setSelectedNotice(item);
     } else {
       try {
@@ -163,7 +164,15 @@ function NoticeTab({ accessToken }) {
             </div>
             <hr />
             <span className="detail-section-title">공지 내용</span>
-            <pre className="detail-text">{selectedNotice.description}</pre>
+            {/* description_html 있으면 HTML로 렌더링, 없으면 텍스트 폴백 */}
+            {selectedNotice.description_html ? (
+              <div
+                className="detail-html-content"
+                dangerouslySetInnerHTML={{ __html: selectedNotice.description_html }}
+              />
+            ) : (
+              <pre className="detail-text">{selectedNotice.description}</pre>
+            )}
             {selectedNotice.url && (
               <div className="detail-footer">
                 <a href={selectedNotice.url} target="_blank" rel="noopener noreferrer" className="lms-link">

--- a/client/src/Components/notice-tab/NoticeTab.jsx
+++ b/client/src/Components/notice-tab/NoticeTab.jsx
@@ -3,35 +3,39 @@ import { createPortal } from 'react-dom';
 import { create } from 'zustand';
 import './NoticeTab.css';
 import '../assignment-tab/AssignmentDetail.css';
+import { API_BASE_URL } from '../../apiConfig';
 
-// 목데이터 정의
-const MOCK_NOTICES = [
-  {
-    course_id: "1",
-    course_name: "컴퓨터 구조",
-    assignment_name: "중간고사 공지",
-    description: "이번 컴퓨터 구조 중간고사 너무 못봤다...",
-    url: "https://lms.chungbuk.ac.kr"
-  },
-  {
-    course_id: "1",
-    course_name: "컴퓨터 구조",
-    assignment_name: "중간고사 점수 확인 관련",
-    description: "중간고사 성적 잘 받고 싶다...",
-    url: "https://lms.chungbuk.ac.kr"
-  },
-  {
-    course_id: "2",
-    course_name: "알고리즘",
-    assignment_name: "기말고사 안내",
-    description: "알고리즘 기말고사는 쉬웠으면 좋겠다...",
-    url: "https://lms.chungbuk.ac.kr"
+
+// Zustand 스토어
+const useNoticeStore = create((set, get) => ({
+  notices: [],
+  isLoading: false,
+  isFetched: false,
+
+  fetchNotices: async (accessToken) => {
+    if (get().isFetched || !accessToken) return;  // 중복 호출 방지
+
+    set({ isLoading: true });
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/notices`, {
+        headers: { 'Authorization': `Bearer ${accessToken}` },
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        throw new Error(`서버 응답 오류 (Status: ${response.status})`);
+      }
+      
+      const result = await response.json();
+      if (result.success) {
+        set({ notices: result.data, isFetched: true });
+      }
+    } catch (error) {
+      console.error("공지사항 로드 실패:", error);
+    } finally {
+      set({ isLoading: false });
+    }
   }
-];
-
-// Zustand 스토어 선언
-const useNoticeStore = create((set) => ({
-  notices: MOCK_NOTICES,
 }));
 
 

--- a/client/src/Components/notice-tab/NoticeTab.jsx
+++ b/client/src/Components/notice-tab/NoticeTab.jsx
@@ -125,7 +125,7 @@ function NoticeTab({ accessToken }) {
 
       {/* 공지 리스트 렌더링 */}
       {isLoading ? (
-        <p className="notice-empty">공지사항을 불러오는 중입니다...</p>
+        <div className="notice-empty">공지사항을 불러오는 중입니다...</div>
       ) : (
 
       <ul className="notice-list">
@@ -143,6 +143,11 @@ function NoticeTab({ accessToken }) {
               <div className="notice-title-area">
                 <span className="notice-course-tag">[{item.course_name}]</span>
                 <span className="notice-item-title">{item.title}</span>
+                {item.date && (
+                  <span className="notice-item-date">
+                    {item.date.slice(0, 10)}  {/* 날짜 부분만 표시 */}
+                  </span>
+                 )}
               </div>
             </li>
           ))
@@ -156,11 +161,13 @@ function NoticeTab({ accessToken }) {
           <div className="detail-modal" onClick={e => e.stopPropagation()}>
             <button className="close-btn" onClick={() => setSelectedNotice(null)}>✕</button>
             <h3>공지 상세 정보</h3>
+            <div className="detail-modal-body">
             <div className="detail-info">
               <p><strong>과목:</strong> {selectedNotice.course_name}</p>
               <p><strong>제목:</strong> {selectedNotice.title}</p>
               {selectedNotice.writer && <p><strong>작성자:</strong> {selectedNotice.writer}</p>}
-              {selectedNotice.date && <p><strong>작성일:</strong> {selectedNotice.date}</p>}
+              {selectedNotice.date && ( <p><strong>작성일: </strong> 
+                {selectedNotice.date.replace(/(\d{4}-\d{2}-\d{2})\s*(\d{2})(\d{2})(\d{2})/, '$1 $2:$3')}</p>)}
             </div>
             <hr />
             <span className="detail-section-title">공지 내용</span>
@@ -180,6 +187,7 @@ function NoticeTab({ accessToken }) {
                 </a>
               </div>
             )}
+            </div> 
           </div>
         </div>,
         document.body

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -71,6 +71,17 @@
   --login-focus-shadow: rgba(33, 150, 243, 0.12);
   --login-button-shadow: rgba(33, 150, 243, 0.25);
   --login-card-shadow: rgba(20, 40, 70, 0.1);
+
+  --tag-color-0: #1565c0; /* 다크 블루 */
+  --tag-color-1: #c62828; /* 다크 레드 */
+  --tag-color-2: #d84315; /* 번트 오렌지 */
+  --tag-color-3: #2e7d32; /* 다크 그린 */
+  --tag-color-4: #ad1457; /* 다크 핑크 */
+  --tag-color-5: #6a1b9a; /* 다크 보라 */
+  --tag-color-6: #00838f; /* 다크 청록 */
+  --tag-color-7: #558b2f; /* 올리브 그린 */
+  --tag-color-8: #c2185b; /* 다크 마젠타 */
+  --tag-color-9: #4527a0; /* 다크 인디고 */
  
   /* 기타 */
   --backdrop:    blur(8px);
@@ -149,6 +160,17 @@
   --login-focus-shadow: rgba(96, 165, 250, 0.22);
   --login-button-shadow: rgba(96, 165, 250, 0.25);
   --login-card-shadow: rgba(0, 0, 0, 0.28);
+
+  --tag-color-0: #8ab4f8; /* 파스텔 파랑 */
+  --tag-color-1: #f28b82; /* 파스텔 빨강 */
+  --tag-color-2: #fde293; /* 파스텔 노랑 */
+  --tag-color-3: #81c995; /* 파스텔 초록 */
+  --tag-color-4: #f48fb1; /* 파스텔 핑크 */
+  --tag-color-5: #c58af9; /* 파스텔 보라 */
+  --tag-color-6: #4fc3f7; /* 파스텔 청록 */
+  --tag-color-7: #aed581; /* 파스텔 연두 */
+  --tag-color-8: #ffb74d; /* 파스텔 주황 */
+  --tag-color-9: #ba68c8; /* 파스텔 연보라 */
 }
  
 @media (prefers-color-scheme: dark) {
@@ -214,6 +236,17 @@
     --login-focus-shadow: rgba(96, 165, 250, 0.22);
     --login-button-shadow: rgba(96, 165, 250, 0.25);
     --login-card-shadow: rgba(0, 0, 0, 0.28);
+
+    --tag-color-0: #8ab4f8; /* 파스텔 파랑 */
+    --tag-color-1: #f28b82; /* 파스텔 빨강 */
+    --tag-color-2: #fde293; /* 파스텔 노랑 */
+    --tag-color-3: #81c995; /* 파스텔 초록 */
+    --tag-color-4: #f48fb1; /* 파스텔 핑크 */
+    --tag-color-5: #c58af9; /* 파스텔 보라 */
+    --tag-color-6: #4fc3f7; /* 파스텔 청록 */
+    --tag-color-7: #aed581; /* 파스텔 연두 */
+    --tag-color-8: #ffb74d; /* 파스텔 주황 */
+    --tag-color-9: #ba68c8; /* 파스텔 연보라 */
 
   }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -72,17 +72,17 @@
   --login-button-shadow: rgba(33, 150, 243, 0.25);
   --login-card-shadow: rgba(20, 40, 70, 0.1);
 
-  --tag-color-0: #1565c0; /* 다크 블루 */
+  --tag-color-0: #146bcf; /* 다크 블루 */
   --tag-color-1: #c62828; /* 다크 레드 */
-  --tag-color-2: #d84315; /* 번트 오렌지 */
+  --tag-color-2: #e65100; /* 다크 오렌지 */
   --tag-color-3: #2e7d32; /* 다크 그린 */
   --tag-color-4: #ad1457; /* 다크 핑크 */
   --tag-color-5: #6a1b9a; /* 다크 보라 */
-  --tag-color-6: #00838f; /* 다크 청록 */
-  --tag-color-7: #558b2f; /* 올리브 그린 */
-  --tag-color-8: #c2185b; /* 다크 마젠타 */
-  --tag-color-9: #4527a0; /* 다크 인디고 */
- 
+  --tag-color-6: #00838f; /* 다크 청록 (시안) */
+  --tag-color-7: #ce9614; /* 다크 옐로우 (골드) */
+  --tag-color-8: #003e33; /* 다크 민트 (딥 틸) */
+  --tag-color-9: #3e2723; /* 다크 브라운 */
+
   /* 기타 */
   --backdrop:    blur(8px);
   --spacing-md:  16px;
@@ -161,16 +161,16 @@
   --login-button-shadow: rgba(96, 165, 250, 0.25);
   --login-card-shadow: rgba(0, 0, 0, 0.28);
 
-  --tag-color-0: #8ab4f8; /* 파스텔 파랑 */
-  --tag-color-1: #f28b82; /* 파스텔 빨강 */
-  --tag-color-2: #fde293; /* 파스텔 노랑 */
-  --tag-color-3: #81c995; /* 파스텔 초록 */
-  --tag-color-4: #f48fb1; /* 파스텔 핑크 */
-  --tag-color-5: #c58af9; /* 파스텔 보라 */
-  --tag-color-6: #4fc3f7; /* 파스텔 청록 */
-  --tag-color-7: #aed581; /* 파스텔 연두 */
-  --tag-color-8: #ffb74d; /* 파스텔 주황 */
-  --tag-color-9: #ba68c8; /* 파스텔 연보라 */
+  --tag-color-0: #7daefd; /* 0. 파스텔 파랑 */
+  --tag-color-1: #fe7b6f; /* 1. 파스텔 빨강 */
+  --tag-color-2: #fe8b43; /* 2. 파스텔 주황 */
+  --tag-color-3: #91e0a7; /* 3. 파스텔 초록 */
+  --tag-color-4: #f877a2; /* 4. 파스텔 핑크 */
+  --tag-color-5: #c274f9; /* 5. 파스텔 보라 */
+  --tag-color-6: #4fe9f7; /* 6. 파스텔 청록 */
+  --tag-color-7: #ffe876; /* 7. 파스텔 노랑 */
+  --tag-color-8: #4ddacb; /* 8. 파스텔 민트 */
+  --tag-color-9: #ff9f85; /* 9. 파스텔 코랄 */
 }
  
 @media (prefers-color-scheme: dark) {
@@ -237,16 +237,16 @@
     --login-button-shadow: rgba(96, 165, 250, 0.25);
     --login-card-shadow: rgba(0, 0, 0, 0.28);
 
-    --tag-color-0: #8ab4f8; /* 파스텔 파랑 */
-    --tag-color-1: #f28b82; /* 파스텔 빨강 */
-    --tag-color-2: #fde293; /* 파스텔 노랑 */
-    --tag-color-3: #81c995; /* 파스텔 초록 */
-    --tag-color-4: #f48fb1; /* 파스텔 핑크 */
-    --tag-color-5: #c58af9; /* 파스텔 보라 */
-    --tag-color-6: #4fc3f7; /* 파스텔 청록 */
-    --tag-color-7: #aed581; /* 파스텔 연두 */
-    --tag-color-8: #ffb74d; /* 파스텔 주황 */
-    --tag-color-9: #ba68c8; /* 파스텔 연보라 */
+    --tag-color-0: #7daefd; /* 0. 파스텔 파랑 */
+    --tag-color-1: #fe7b6f; /* 1. 파스텔 빨강 */
+    --tag-color-2: #fe8b43; /* 2. 파스텔 주황 */
+    --tag-color-3: #91e0a7; /* 3. 파스텔 초록 */
+    --tag-color-4: #f877a2; /* 4. 파스텔 핑크 */
+    --tag-color-5: #c274f9; /* 5. 파스텔 보라 */
+    --tag-color-6: #4fe9f7; /* 6. 파스텔 청록 */
+    --tag-color-7: #ffe876; /* 7. 파스텔 노랑 */
+    --tag-color-8: #4ddacb; /* 8. 파스텔 민트 */
+    --tag-color-9: #ff9f85; /* 9. 파스텔 코랄 */
 
   }
 }

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -14,6 +14,7 @@ import os
 # 내부 모듈 임포트
 from lms_login import login_to_lms
 from lms_crawler import crawl_all_assignments, SessionExpiredError, get_user_profile
+from notice_crawler import crawl_all_notices, get_notice_detail  
 import auth
 import storage
 import redis_cache
@@ -113,6 +114,28 @@ class CustomAssignmentRequest(BaseModel):
     isSubmitted: bool = False
     description: Optional[str] = Field(None, max_length=1000)
 
+class NoticeItem(BaseModel): # 공지사항 개별 항목 스키마
+    course_id: str
+    course_name: str
+    board_id: str
+    notice_id: str
+    title: str
+    writer: str
+    date: str
+    description: str
+    url: str
+
+class NoticeListResponse(BaseModel): # 공지사항 목록 응답 스키마
+    success: bool
+    message: str
+    total_count: int
+    data: List[NoticeItem] = []
+
+class NoticeDetailResponse(BaseModel): # 공지사항 상세 응답 스키마
+    success: bool
+    message: str
+    data: dict
+    
 security = HTTPBearer() # 인증 객체
 
 # 입력: credentials (HTTP 헤더 인증 정보)

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -511,22 +511,28 @@ def get_notices(student_id: str = Depends(get_current_user)):
         logger.error(f"공지사항 조회 실패: {e}")
         raise HTTPException(status_code=500, detail="공지사항 조회 실패")
  
+ 
 # 입력: board_id (게시판 ID), notice_id (게시글 ID), student_id (학번)
 # 기능: 공지사항 상세 본문 크롤링
 # 반환: NoticeDetailResponse
+
+# 에러 처리:
+#   - 잘못된 board_id/notice_id 입력 시 LMS가 에러 페이지를 반환
+#     → 크롤러에서 title_tag 파싱 실패 → ValueError 발생 → 404 반환
+#   - 위를 통해 사용자의 잘못된 요청(404)과 서버 내부 오류(500)를 구분
+
 @app.get("/api/notices/{board_id}/{notice_id}", response_model=NoticeDetailResponse)
 def get_notice_detail_api(board_id: str, notice_id: str, student_id: str = Depends(get_current_user)):
     session = resolve_lms_session(student_id)
- 
+
     try:
         detail = get_notice_detail(session, board_id, notice_id)
         return NoticeDetailResponse(success=True, message="성공", data=detail)
     except SessionExpiredError:
         raise HTTPException(status_code=401, detail="LMS 세션이 만료되었습니다.")
+    except ValueError as e:
+        # 크롤러에서 올린 404 케이스 (잘못된 board_id/notice_id)
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         logger.error(f"공지사항 상세 조회 실패: {e}")
         raise HTTPException(status_code=500, detail="공지사항 상세 조회 실패")
-
-
-if __name__ == "__main__":
-    uvicorn.run("assignment_api:app", host="0.0.0.0", port=8000, reload=True)

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -536,3 +536,7 @@ def get_notice_detail_api(board_id: str, notice_id: str, student_id: str = Depen
     except Exception as e:
         logger.error(f"공지사항 상세 조회 실패: {e}")
         raise HTTPException(status_code=500, detail="공지사항 상세 조회 실패")
+    
+    
+if __name__ == "__main__":
+    uvicorn.run("assignment_api:app", host="0.0.0.0", port=8000, reload=True)

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -474,7 +474,7 @@ def delete_notification_history(history_id: int, student_id: str = Depends(get_c
 # 반환: NoticeListResponse
 @app.get("/api/notices", response_model=NoticeListResponse)
 def get_notices(student_id: str = Depends(get_current_user)):
-    session = get_lms_session(student_id)
+    session = redis_cache.get_lms_session(student_id)
  
     try:
         notices = crawl_all_notices(session)
@@ -490,6 +490,22 @@ def get_notices(student_id: str = Depends(get_current_user)):
         logger.error(f"공지사항 조회 실패: {e}")
         raise HTTPException(status_code=500, detail="공지사항 조회 실패")
  
+# 입력: board_id (게시판 ID), notice_id (게시글 ID), student_id (학번)
+# 기능: 공지사항 상세 본문 크롤링
+# 반환: NoticeDetailResponse
+@app.get("/api/notices/{board_id}/{notice_id}", response_model=NoticeDetailResponse)
+def get_notice_detail_api(board_id: str, notice_id: str, student_id: str = Depends(get_current_user)):
+    session = redis_cache.get_lms_session(student_id)
  
+    try:
+        detail = get_notice_detail(session, board_id, notice_id)
+        return NoticeDetailResponse(success=True, message="성공", data=detail)
+    except SessionExpiredError:
+        raise HTTPException(status_code=401, detail="LMS 세션이 만료되었습니다.")
+    except Exception as e:
+        logger.error(f"공지사항 상세 조회 실패: {e}")
+        raise HTTPException(status_code=500, detail="공지사항 상세 조회 실패")
+
+
 if __name__ == "__main__":
     uvicorn.run("assignment_api:app", host="0.0.0.0", port=8000, reload=True)

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -163,6 +163,24 @@ def set_refresh_cookie(response: Response, refresh_token: str, request: Request)
         path="/"
     )
 
+# 입력: student_id (학번)
+# 기능: Redis 캐시에서 LMS 세션 복원, 없으면 저장된 계정으로 재로그인
+# 반환: requests.Session 객체
+def resolve_lms_session(student_id: str) -> requests.Session:
+    cached_cookies = redis_cache.get_lms_session(student_id)
+    
+    session = requests.Session()
+    if cached_cookies:
+        session.cookies.update(cached_cookies)
+    else:
+        loaded_id, password = storage.load_user(student_id)
+        session, message = login_to_lms(loaded_id, password)
+        if not session:
+            raise HTTPException(status_code=401, detail="LMS 세션이 만료되었습니다. 다시 로그인해주세요.")
+        redis_cache.set_lms_session(student_id, session.cookies.get_dict())
+    return session
+
+
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
@@ -286,17 +304,7 @@ def logout(response: Response, student_id: str = Depends(get_current_user)):
 # 반환: UserProfileResponse 객체
 @app.get("/api/me", response_model=UserProfileResponse)
 def get_my_profile(student_id: str = Depends(get_current_user)):
-    cached_cookies = redis_cache.get_lms_session(student_id)
-
-    session = requests.Session()
-    if cached_cookies:
-        session.cookies.update(cached_cookies)
-    else:
-        loaded_id, password = storage.load_user(student_id)
-        session, _ = login_to_lms(loaded_id, password)
-        if not session:
-            raise HTTPException(status_code=401, detail="LMS 세션을 생성할 수 없습니다.")
-        redis_cache.set_lms_session(student_id, session.cookies.get_dict())
+    session = resolve_lms_session(student_id)
 
     try:
         profile = get_user_profile(session, student_id)
@@ -310,19 +318,7 @@ def get_my_profile(student_id: str = Depends(get_current_user)):
 # 반환: LMSAPIResponse 객체
 @app.get("/api/assignments", response_model=LMSAPIResponse)
 def get_lms_assignments(student_id: str = Depends(get_current_user)):
-    cached_cookies = redis_cache.get_lms_session(student_id)
-
-    session = requests.Session()
-    if cached_cookies:
-        session.cookies.update(cached_cookies)
-    else:
-        loaded_id, password = storage.load_user(student_id)
-        session, message = login_to_lms(loaded_id, password)
-        if not session:
-            logger.error(f"LMS 로그인 실패 (학번: {student_id}): {message}")
-            raise HTTPException(status_code=401, detail="LMS 세션이 만료되었습니다. 다시 로그인해주세요.")
-        
-        redis_cache.set_lms_session(student_id, session.cookies.get_dict())
+    session = resolve_lms_session(student_id)
     
     try:
         assignments = crawl_all_assignments(session)
@@ -474,8 +470,8 @@ def delete_notification_history(history_id: int, student_id: str = Depends(get_c
 # 반환: NoticeListResponse
 @app.get("/api/notices", response_model=NoticeListResponse)
 def get_notices(student_id: str = Depends(get_current_user)):
-    session = redis_cache.get_lms_session(student_id)
- 
+    session = resolve_lms_session(student_id)
+    
     try:
         notices = crawl_all_notices(session)
         return NoticeListResponse(
@@ -495,7 +491,7 @@ def get_notices(student_id: str = Depends(get_current_user)):
 # 반환: NoticeDetailResponse
 @app.get("/api/notices/{board_id}/{notice_id}", response_model=NoticeDetailResponse)
 def get_notice_detail_api(board_id: str, notice_id: str, student_id: str = Depends(get_current_user)):
-    session = redis_cache.get_lms_session(student_id)
+    session = resolve_lms_session(student_id)
  
     try:
         detail = get_notice_detail(session, board_id, notice_id)

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -467,6 +467,29 @@ def delete_notification_history(history_id: int, student_id: str = Depends(get_c
     except Exception as e:
         logger.error(f"알림 내역 삭제 실패: {e}")
         raise HTTPException(status_code=500, detail="삭제 실패")
-
+    
+    
+# 입력: student_id (학번)
+# 기능: 전체 수강 과목 공지사항 목록 크롤링
+# 반환: NoticeListResponse
+@app.get("/api/notices", response_model=NoticeListResponse)
+def get_notices(student_id: str = Depends(get_current_user)):
+    session = get_lms_session(student_id)
+ 
+    try:
+        notices = crawl_all_notices(session)
+        return NoticeListResponse(
+            success=True,
+            message="성공",
+            total_count=len(notices),
+            data=notices
+        )
+    except SessionExpiredError:
+        raise HTTPException(status_code=401, detail="LMS 세션이 만료되었습니다.")
+    except Exception as e:
+        logger.error(f"공지사항 조회 실패: {e}")
+        raise HTTPException(status_code=500, detail="공지사항 조회 실패")
+ 
+ 
 if __name__ == "__main__":
     uvicorn.run("assignment_api:app", host="0.0.0.0", port=8000, reload=True)

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -163,6 +163,21 @@ def set_refresh_cookie(response: Response, refresh_token: str, request: Request)
         path="/"
     )
 
+# 입력: session (requests.Session 객체)
+# 기능: LMS 대시보드 요청으로 세션 유효성 확인
+# 반환: 유효 여부 (bool)
+def _is_lms_session_valid(session: requests.Session) -> bool:
+    try:
+        resp = session.get(
+            "https://lms.chungbuk.ac.kr/",
+            timeout=5,
+            allow_redirects=False
+        )
+        # 302 = 로그인 페이지로 튕김 = 만료
+        return resp.status_code == 200
+    except Exception:
+        return False
+
 # 입력: student_id (학번)
 # 기능: Redis 캐시에서 LMS 세션 복원, 없으면 저장된 계정으로 재로그인
 # 반환: requests.Session 객체
@@ -170,14 +185,24 @@ def resolve_lms_session(student_id: str) -> requests.Session:
     cached_cookies = redis_cache.get_lms_session(student_id)
     
     session = requests.Session()
+    
     if cached_cookies:
         session.cookies.update(cached_cookies)
-    else:
-        loaded_id, password = storage.load_user(student_id)
-        session, message = login_to_lms(loaded_id, password)
-        if not session:
-            raise HTTPException(status_code=401, detail="LMS 세션이 만료되었습니다. 다시 로그인해주세요.")
-        redis_cache.set_lms_session(student_id, session.cookies.get_dict())
+        
+        if _is_lms_session_valid(session):
+            return session
+        
+        # 만료된 경우 Redis 캐시 삭제 후 재로그인
+        logger.warning(f"캐시된 LMS 세션 만료 감지, 재로그인 시도 (student_id: {student_id})")
+        redis_cache.delete_lms_session(student_id)
+        session = requests.Session()
+   
+   
+    loaded_id, password = storage.load_user(student_id)
+    session, message = login_to_lms(loaded_id, password)
+    if not session:
+        raise HTTPException(status_code=401, detail="LMS 세션이 만료되었습니다. 다시 로그인해주세요.")
+    redis_cache.set_lms_session(student_id, session.cookies.get_dict())
     return session
 
 

--- a/server/assignment_api.py
+++ b/server/assignment_api.py
@@ -14,7 +14,7 @@ import os
 # 내부 모듈 임포트
 from lms_login import login_to_lms
 from lms_crawler import crawl_all_assignments, SessionExpiredError, get_user_profile
-from notice_crawler import crawl_all_notices, get_notice_detail  
+from notice_crawler import crawl_all_notices, get_notice_detail, crawl_all_messages
 import auth
 import storage
 import redis_cache
@@ -135,6 +135,19 @@ class NoticeDetailResponse(BaseModel): # 공지사항 상세 응답 스키마
     success: bool
     message: str
     data: dict
+    
+class MessageItem(BaseModel): # 쪽지 개별 항목 스키마
+    message_id: str
+    sender: str
+    content: str
+    date: str
+    url: str
+
+class MessageListResponse(BaseModel): # 쪽지 목록 API 응답 스키마
+    success: bool
+    message: str
+    total_count: int
+    data: List[MessageItem] = []
     
 security = HTTPBearer() # 인증 객체
 
@@ -537,6 +550,26 @@ def get_notice_detail_api(board_id: str, notice_id: str, student_id: str = Depen
         logger.error(f"공지사항 상세 조회 실패: {e}")
         raise HTTPException(status_code=500, detail="공지사항 상세 조회 실패")
     
+# 입력: student_id (학번)
+# 기능: LMS 받은 쪽지 목록 크롤링 및 반환
+# 반환: MessageListResponse
+@app.get("/api/messages", response_model=MessageListResponse)
+def get_lms_messages(student_id: str = Depends(get_current_user)):
+    session = resolve_lms_session(student_id)
+    try:
+        messages = crawl_all_messages(session)
+        return MessageListResponse(
+            success=True, 
+            message="성공", 
+            total_count=len(messages), 
+            data=messages
+        )
+    except SessionExpiredError:
+        raise HTTPException(status_code=401, detail="LMS 세션이 만료되었습니다.")
+    except Exception:
+        logger.exception("쪽지 목록 조회 실패")
+        raise HTTPException(status_code=500, detail="쪽지 목록 조회 실패")
     
+
 if __name__ == "__main__":
     uvicorn.run("assignment_api:app", host="0.0.0.0", port=8000, reload=True)

--- a/server/notice_crawler.py
+++ b/server/notice_crawler.py
@@ -197,3 +197,43 @@ def get_notice_detail(session, board_id, notice_id):
     except Exception as e:
         logger.error(f"공지사항 상세 조회 중 오류 (Notice ID: {notice_id}): {e}")
         raise Exception(f"공지사항 상세 조회 중 오류: {e}")
+
+
+# 입력: session (세션 객체)
+# 기능: 전체 수강 과목의 공지사항 통합 크롤링
+# 반환: 공지 리스트
+# ThreadPoolExecutor를 사용한 멀티스레드 병렬 크롤링
+def crawl_all_notices(session, common_board_ids=None):
+    if common_board_ids is None:
+        common_board_ids = COMMON_BOARD_IDS
+
+    all_notices = []
+    courses = get_enrolled_courses(session)
+    if not courses:
+        return []
+
+    # 과목별 처리를 위한 래퍼 함수 정의 (예외 처리를 개별적으로 수행하기 위함)
+    def worker(course_info):
+        cid, cname = course_info
+        try:
+            return get_notices_for_course(session, cid, cname, common_board_ids=common_board_ids)
+        except SessionExpiredError:
+            return None
+        except Exception:
+            return []
+
+    # 최대 스레드 수는 수강 과목 수에 맞춤
+    with ThreadPoolExecutor(max_workers=7) as executor:
+        results = executor.map(worker, courses.items())
+        
+        for notice_list in results:
+            if notice_list is None:
+                raise SessionExpiredError("LMS 세션이 만료되었습니다.")
+            
+            if notice_list:
+                all_notices.extend(notice_list)
+
+    # 최신 날짜 순 정렬
+    all_notices.sort(key=lambda x: x['date'], reverse=True)
+
+    return all_notices

--- a/server/notice_crawler.py
+++ b/server/notice_crawler.py
@@ -253,3 +253,63 @@ def crawl_all_notices(session, common_board_ids=None):
     all_notices.sort(key=lambda x: x['date'], reverse=True)
 
     return all_notices
+
+# 입력: session (requests.Session 객체)
+# 기능: LMS 받은 쪽지 목록 크롤링
+# 반환: 쪽지 정보 딕셔너리 리스트
+def crawl_all_messages(session):
+    url = "https://lms.chungbuk.ac.kr/local/ubsend/message/"
+    messages = []
+    
+    try:
+        resp = session.get(url, timeout=10, allow_redirects=False)
+        if resp.status_code in [302, 401]:
+            raise SessionExpiredError("LMS 세션이 만료되었습니다.")
+            
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        
+        # 실제 LMS 구조: table이 아니라 <li class="media"> 형태의 리스트임
+        message_items = soup.select('li.media')
+        
+        for idx, item in enumerate(message_items):
+            body = item.select_one('div.media-body')
+            if not body:
+                continue
+                
+            link_tag = body.select_one('a')
+            if not link_tag:
+                continue
+                
+            # 1. 보낸 사람 (h4.media-heading)
+            sender_tag = link_tag.select_one('h4.media-heading')
+            sender = sender_tag.get_text(strip=True) if sender_tag else "알 수 없음"
+            
+            # 2. 날짜 (div.time)
+            time_tag = link_tag.select_one('div.time')
+            date = time_tag.get_text(strip=True) if time_tag else ""
+            
+            # 3. 내용 (div.msg)
+            msg_tag = link_tag.select_one('div.msg')
+            content = msg_tag.get_text(strip=True) if msg_tag else ""
+            
+            # 4. 상세 페이지 URL
+            href = link_tag.get('href', '')
+            url_link = href if href.startswith('http') else f"https://lms.chungbuk.ac.kr{href}"
+            
+            message_id = f"{sender}-{idx}"
+            
+            messages.append({
+                'message_id': message_id,
+                'sender': sender,
+                'content': content,
+                'date': date,
+                'url': url_link
+            })
+            
+        return messages
+        
+    except SessionExpiredError:
+        raise
+    except Exception as e:
+        logger.error(f"쪽지 크롤링 중 오류: {e}")
+        return []

--- a/server/notice_crawler.py
+++ b/server/notice_crawler.py
@@ -162,6 +162,12 @@ def get_notice_detail(session, board_id, notice_id):
             raise SessionExpiredError("LMS 세션이 만료되었습니다.")
 
         soup = BeautifulSoup(resp.text, 'html.parser')
+        
+        # 존재하지 않는 게시글이면 LMS가 에러 메시지 페이지를 반환함
+        error_box = soup.select_one('div.alert-danger') or soup.select_one('div#notice')
+        title_tag = soup.select_one('div.article-subject h3')
+        if not title_tag or (error_box and '존재하지' in error_box.get_text()):
+            raise ValueError("존재하지 않는 공지사항입니다.")
 
         title = ""
         title_tag = soup.select_one('div.article-subject h3')

--- a/server/notice_crawler.py
+++ b/server/notice_crawler.py
@@ -184,10 +184,19 @@ def get_notice_detail(session, board_id, notice_id):
             elif '조회수' in text:
                 views = text.replace('조회수', '').replace(':', '').strip()
 
+        # 텍스트 대신 HTML 추출 — 이미지 src를 절대 경로로 변환
         description = ""
+        description_html = ""
         content_tag = soup.select_one('div.article-content div.text_to_html')
         if content_tag:
             description = content_tag.get_text(separator='\n', strip=True)
+
+            # 이미지 src 상대경로 → 절대경로 변환
+            for img in content_tag.find_all('img'):
+                src = img.get('src', '')
+                if src.startswith('/'):
+                    img['src'] = f"https://lms.chungbuk.ac.kr{src}"
+            description_html = str(content_tag)
 
         return {
             'title': title,
@@ -195,6 +204,7 @@ def get_notice_detail(session, board_id, notice_id):
             'date': date,
             'views': views,
             'description': description,
+            'description_html': description_html,  # HTML 버전 추가
             'url': url
         }
 

--- a/server/notice_crawler.py
+++ b/server/notice_crawler.py
@@ -1,0 +1,199 @@
+import urllib.parse
+from bs4 import BeautifulSoup
+import logging
+from concurrent.futures import ThreadPoolExecutor  # 병렬 처리를 위한 모듈
+
+from lms_crawler import SessionExpiredError, get_enrolled_courses
+
+logger = logging.getLogger(__name__)
+
+# 공통 LMS 공지사항 게시판 ID — 제외 목록
+COMMON_BOARD_IDS = {'17'}
+
+# 입력: session (세션 객체), course_id (과목 ID), course_name (과목명)
+# 기능: 특정 과목의 공지사항 게시판 ID 추출 후 공지 목록 크롤링
+# 반환: 공지 정보 딕셔너리 리스트
+def get_notices_for_course(session, course_id, course_name, common_board_ids=None):
+    if common_board_ids is None:
+        common_board_ids = COMMON_BOARD_IDS
+        
+    course_url = f"https://lms.chungbuk.ac.kr/course/view.php?id={course_id}"
+    notices = []
+
+    try:
+        resp = session.get(course_url, timeout=10, allow_redirects=False)
+        if resp.status_code in [302, 401]:
+            raise SessionExpiredError("LMS 세션이 만료되었습니다.")
+
+        soup = BeautifulSoup(resp.text, 'html.parser')
+
+        # 강의실 홈에서 공지사항 게시판 링크 찾기
+        # ubboard 링크 중 과목 ID, 공통 게시판 ID와 다른 첫 번째 링크를 게시판으로 간주
+        board_id = None
+        for a in soup.find_all('a', href=True):
+            href = a['href']
+            if 'mod/ubboard/view.php?id=' in href:
+                parsed = urllib.parse.urlparse(href)
+                bid = urllib.parse.parse_qs(parsed.query).get('id', [None])[0]
+                if bid and bid != course_id and bid not in common_board_ids:
+                    board_id = bid
+                    break
+
+        if not board_id:
+            return []
+
+        # 공지 목록 페이지 크롤링
+        board_url = f"https://lms.chungbuk.ac.kr/mod/ubboard/view.php?id={board_id}"
+        board_resp = session.get(board_url, timeout=10, allow_redirects=False)
+        if board_resp.status_code in [302, 401]:
+            raise SessionExpiredError("LMS 세션이 만료되었습니다.")
+
+        board_soup = BeautifulSoup(board_resp.text, 'html.parser')
+
+        # 상단 고정 공지 — 페이지 최초 진입 시 펼쳐진 공지
+        article_subject = board_soup.select_one('div.article-subject h3')
+        article_info = board_soup.select_one('div.article-info')
+        article_content = board_soup.select_one('div.article-content div.text_to_html')
+
+        # bwid (게시글 ID) 추출 — 목록 첫 번째 링크에서
+        top_bwid = None
+        if article_subject:
+            # div.article-subject 내부에 있는 <a> 태그 혹은 바로 위/아래 부모 블록 내의 링크를 안전하게 탐색합니다.
+            subject_box = board_soup.select_one('div.article-subject')
+            top_link = subject_box.find('a', href=True) if subject_box else None
+            
+            # 만약 제목 내부에 링크가 없다면 article-info 영역 내부의 링크 등 상단 영역에서 bwid 검색
+            if not top_link and article_info:
+                top_link = article_info.find('a', href=True)
+
+            if top_link:
+                href = top_link.get('href', '')
+                parsed_href = urllib.parse.urlparse(href)
+                top_bwid = urllib.parse.parse_qs(parsed_href.query).get('bwid', [None])[0]
+
+        if article_subject and top_bwid:
+            title = article_subject.get_text(strip=True)
+            writer, date = "", ""
+            if article_info:
+                for col in article_info.select('div.col-info'):
+                    text = col.get_text(strip=True)
+                    if '작성자' in text:
+                        writer = text.replace('작성자', '').replace(':', '').strip()
+                    elif '작성일' in text:
+                        date = text.replace('작성일', '').replace(':', '').strip()
+
+            description = ""
+            if article_content:
+                description = article_content.get_text(separator='\n', strip=True)
+
+            notices.append({
+                'course_id': course_id,
+                'course_name': course_name,
+                'board_id': board_id,
+                'notice_id': top_bwid,
+                'title': title,
+                'writer': writer,
+                'date': date,
+                'description': description,
+                'url': f"https://lms.chungbuk.ac.kr/mod/ubboard/article.php?bwid={top_bwid}&id={board_id}"
+            })
+
+        # 목록 테이블에서 나머지 공지 추출
+        table = board_soup.select_one('table.table-ubboard-list tbody')
+        if table:
+            rows = table.find_all('tr')
+            for row in rows:
+                cols = row.find_all('td')
+                if len(cols) < 4:
+                    continue
+
+                a_tag = cols[1].find('a') if len(cols) > 1 else None
+                if not a_tag:
+                    continue
+
+                href = a_tag.get('href', '')
+                parsed_href = urllib.parse.urlparse(href)
+                params = urllib.parse.parse_qs(parsed_href.query)
+
+                # bwid와 id 둘 다 있는 링크만 처리
+                notice_bwid = params.get('bwid', [None])[0]
+                notice_board_id = params.get('id', [None])[0]
+
+                if not notice_bwid or not notice_board_id:
+                    continue
+
+                # 중복 방지 (상단 고정 공지와 id가 다를 때만 추가)
+                if notice_bwid != top_bwid:
+                    title = a_tag.get_text(strip=True)
+                    writer = cols[2].get_text(strip=True) if len(cols) > 2 else ''
+                    date = cols[3].get_text(strip=True) if len(cols) > 3 else ''
+
+                    notices.append({
+                        'course_id': course_id,
+                        'course_name': course_name,
+                        'board_id': notice_board_id,
+                        'notice_id': notice_bwid,
+                        'title': title,
+                        'writer': writer,
+                        'date': date,
+                        'description': '',
+                        'url': f"https://lms.chungbuk.ac.kr/mod/ubboard/article.php?bwid={notice_bwid}&id={notice_board_id}"
+                    })
+
+        return notices
+
+    except SessionExpiredError:
+        raise
+    except Exception as e:
+        logger.error(f"[{course_name}] 공지사항 목록 추출 중 오류 발생: {e}")
+        print(f"공지사항 목록 추출 중 오류: {e}")
+    return []
+
+
+# 입력: session (세션 객체), board_id (게시판 ID), notice_id (게시글 ID)
+# 기능: 공지사항 상세 페이지 크롤링
+# 반환: 상세 정보 딕셔너리
+def get_notice_detail(session, board_id, notice_id):
+    url = f"https://lms.chungbuk.ac.kr/mod/ubboard/article.php?bwid={notice_id}&id={board_id}"
+
+    try:
+        resp = session.get(url, timeout=10, allow_redirects=False)
+        if resp.status_code in [302, 401]:
+            raise SessionExpiredError("LMS 세션이 만료되었습니다.")
+
+        soup = BeautifulSoup(resp.text, 'html.parser')
+
+        title = ""
+        title_tag = soup.select_one('div.article-subject h3')
+        if title_tag:
+            title = title_tag.get_text(strip=True)
+
+        writer, date, views = "", "", ""
+        for col in soup.select('div.article-info div.col-info'):
+            text = col.get_text(strip=True)
+            if '작성자' in text:
+                writer = text.replace('작성자', '').replace(':', '').strip()
+            elif '작성일' in text:
+                date = text.replace('작성일', '').replace(':', '').strip()
+            elif '조회수' in text:
+                views = text.replace('조회수', '').replace(':', '').strip()
+
+        description = ""
+        content_tag = soup.select_one('div.article-content div.text_to_html')
+        if content_tag:
+            description = content_tag.get_text(separator='\n', strip=True)
+
+        return {
+            'title': title,
+            'writer': writer,
+            'date': date,
+            'views': views,
+            'description': description,
+            'url': url
+        }
+
+    except SessionExpiredError:
+        raise
+    except Exception as e:
+        logger.error(f"공지사항 상세 조회 중 오류 (Notice ID: {notice_id}): {e}")
+        raise Exception(f"공지사항 상세 조회 중 오류: {e}")


### PR DESCRIPTION
**구현 내용**
과목 공지사항을 한번에 볼 수 있으며, 각 상세정보 및 lms 연결


**관련 이슈 #71** 


**작업 사항**
- 과목별 공지 목록 및 상세 크롤링 함수 구현
- /api/notices, /api/notices/{board_id}/{notice_id} 엔드포인트 추가
-  resolve_lms_session() 헬퍼 함수 구현 및 전체 엔드포인트 적용



**수정  사항 및 참고**
 - assignment_api.py 에서 /api/me, /api/assignments 를 포함한 작업 코드( /api/notices, /api/notices/{board_id}/{notice_id} ) 에서 딕셔너리 -> 세션 복원 코드가 4번 중복되며, 파일 코드 수가 너무 길어지는 것 같아서 수정했습니다. 
-> resolve_lms_session() 헬프 함수 구현하여 사용함

- NoticeTab.jsx의 상세보기 lms 이동을 하면 처음 및 일정 시간 후, 직접 lms에 로그인을 해야함
예상 원인 
링크를 클릭하면 브라우저가 직접 LMS로 가는데, 브라우저엔 LMS 세션 쿠키가 없으니까 로그인 페이지로 튕김